### PR TITLE
Refactor variant gui api calls

### DIFF
--- a/src/Macintosh Code Release 3/items.cpp
+++ b/src/Macintosh Code Release 3/items.cpp
@@ -13,7 +13,6 @@
 #include "fields.h"
 #include "loc_utils.h"
 #include "newgraph.h"
-#include "dlogtool.h"
 #include "item_data.h"
 #include "info.dialogs.h"
 #include "Exile.sound.h"

--- a/src/Windows Code Release 3/PC editor/dlogtool.cpp
+++ b/src/Windows Code Release 3/PC editor/dlogtool.cpp
@@ -1264,8 +1264,8 @@ void cd_draw_item(short dlog_num,short item_num)
 				case 5:
 					if (item_flag[item_index] == -1)
 						cd_erase_item(dlog_num,item_num);
-						else draw_dialog_graphic(dlgs[dlg_index], item_rect[item_index],
-							item_flag[item_index],(item_flag[item_index] >= 2000) ? FALSE : TRUE,0);
+						else draw_dialog_graphic_wnd(dlgs[dlg_index], item_rect[item_index],
+							item_flag[item_index],(item_flag[item_index] >= 2000) ? FALSE : TRUE);
 					break;
 				}
 			}

--- a/src/Windows Code Release 3/PC editor/dlogtool.cpp
+++ b/src/Windows Code Release 3/PC editor/dlogtool.cpp
@@ -1437,7 +1437,7 @@ void cd_erase_item(short dlog_num, short item_num)
 	Rectangle(win_dc,to_fry.left, to_fry.top,to_fry.right,to_fry.bottom);
 	SelectObject(win_dc,old_brush);
 	SelectObject(win_dc,old_pen);  */
-	paint_pattern(win_dc,2,to_fry,0);
+	paint_pattern_dc(win_dc,to_fry,0);
 	cd_kill_dc(dlg_index,win_dc);  
 
 
@@ -1462,7 +1462,7 @@ void cd_erase_rect(short dlog_num,RECT to_fry)
 	Rectangle(win_dc,to_fry.left, to_fry.top,to_fry.right,to_fry.bottom);
 	SelectObject(win_dc,old_brush);
 	SelectObject(win_dc,old_pen);  */
-	paint_pattern(win_dc,2,to_fry,0);
+	paint_pattern_dc(win_dc,to_fry,0);
 	cd_kill_dc(dlg_index,win_dc);
 
 	//	paint_pattern(dlgs[dlg_index],2,to_fry,0);
@@ -1765,7 +1765,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 		}
 	if (which_g == 950) { // Empty. Maybe clear space.
 		if (win_or_gworld == 0) {
-			paint_pattern(hdc,2,rect,0);
+			paint_pattern_dc(hdc,rect,0);
 
 			//old_brush = SelectObject(hdc,bg[5]);
 			//Rectangle(hdc,rect.left,rect.top,rect.right,rect.bottom);

--- a/src/Windows Code Release 3/PC editor/dlogtool.cpp
+++ b/src/Windows Code Release 3/PC editor/dlogtool.cpp
@@ -1198,7 +1198,7 @@ void cd_draw_item(short dlog_num,short item_num)
 					from_rect.left = button_ul_x[button_type[item_flag[item_index]]];
 					from_rect.bottom = from_rect.top + button_height[button_type[item_flag[item_index]]];
 					from_rect.right = from_rect.left + button_width[button_type[item_flag[item_index]]];
-					rect_draw_some_item(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+					rect_draw_some_item_dc(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 					SelectObject(win_dc,bold_font);
 					SetTextColor(win_dc,PALETTEINDEX(c[2]));
@@ -1227,7 +1227,7 @@ void cd_draw_item(short dlog_num,short item_num)
 						}
 					from_rect.right = from_rect.left + 14;
 					from_rect.bottom = from_rect.top + 10;
-					rect_draw_some_item( dlg_buttons_gworld,from_rect, win_dc,item_rect[item_index],0,2); break;
+					rect_draw_some_item_dc( dlg_buttons_gworld,from_rect, win_dc,item_rect[item_index],0,2); break;
 					break;
 
 				case 3: case 4: case 7: case 8: case 9:
@@ -1494,7 +1494,7 @@ void cd_press_button(short dlog_num, short item_num)
 					from_rect.bottom = from_rect.top + button_height[item_flag[item_index]];
 					from_rect.right = from_rect.left + button_width[item_flag[item_index]];
 	OffsetRect(&from_rect,button_width[item_flag[item_index]],0);
-	rect_draw_some_item(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 	if (play_sounds == TRUE) {
 		play_sound(37);
@@ -1503,7 +1503,7 @@ void cd_press_button(short dlog_num, short item_num)
 		else Delay(14,&dummy);
 
 	OffsetRect(&from_rect,-1 * button_width[item_flag[item_index]],0);
-	rect_draw_some_item(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 	*/
 	
 	from_rect.top = button_ul_y[button_type[item_flag[item_index]]];
@@ -1512,7 +1512,7 @@ void cd_press_button(short dlog_num, short item_num)
 	from_rect.right = from_rect.left + button_width[button_type[item_flag[item_index]]];
 	OffsetRect(&from_rect,button_width[button_type[item_flag[item_index]]],0);
 	
-	rect_draw_some_item(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 	SelectObject(win_dc,bold_font);
 	SetTextColor(win_dc,PALETTEINDEX(c[2]));
@@ -1537,7 +1537,7 @@ void cd_press_button(short dlog_num, short item_num)
 		else Delay(10,&dummy);
 
 	OffsetRect(&from_rect,-1 * button_width[button_type[item_flag[item_index]]],0);
-	rect_draw_some_item(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 	SelectObject(win_dc,bold_font);
 	SetTextColor(win_dc,PALETTEINDEX(c[1]));
@@ -1783,21 +1783,21 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				which_g -= 700;
 			from_gworld = dlogpics_gworld;
 			OffsetRect(&from2,36 * (which_g % 4),36 * (which_g / 4));
-			rect_draw_some_item(from_gworld,from2,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from2,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			break;
 		case 11: // item info help
 			from_rect = item_info_from;
 			rect.right = rect.left + from_rect.right - from_rect.left;
 			rect.bottom = rect.top + from_rect.bottom - from_rect.top;
-			rect_draw_some_item(mixed_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			break;
 		case 12: // item info help
 			from_rect = pc_info_from;
 			rect.right = rect.left + pc_info_from.right - pc_info_from.left;
 			rect.bottom = rect.top + pc_info_from.bottom - pc_info_from.top;
-			rect_draw_some_item(mixed_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			break;
 		case 14: // button help
@@ -1806,7 +1806,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				from_gworld = load_pict(900 + which_g,hdc);
 				from_rect = large_scen_from;
 				OffsetRect(&from_rect,64 * (which_g % 10),0);
-				rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 				  ,rect,0,draw_dest);
 				DeleteObject(from_gworld);
 				break;
@@ -1817,7 +1817,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			rect.right = rect.left + from_rect.right;
 			rect.bottom = rect.top + from_rect.bottom;
 			OffsetRect(&from_rect,0,100 * which_g);
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;
@@ -1831,7 +1831,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			OffsetRect(&from_rect,32 * (which_g % 5),32 * (which_g / 5));
 			rect.right = rect.left + 32;
 			rect.bottom = rect.top + 32;
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP) (hDlg): hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;

--- a/src/Windows Code Release 3/PC editor/dlogtool.h
+++ b/src/Windows Code Release 3/PC editor/dlogtool.h
@@ -39,7 +39,13 @@ short cd_get_item_id(short dlg_num, short item_num);
 void center_window(HWND window);
 RECT get_item_rect(HWND hDlg, short item_num);
 void frame_dlog_rect(HWND hDlg, RECT rect, short val);
-void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld)   ;
+void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld);
+
+inline void draw_dialog_graphic_wnd(HWND hDlg, RECT rect, short which_g, Boolean do_frame)
+{
+	draw_dialog_graphic(hDlg, rect, which_g, do_frame, 0);
+}
+
 void showcursor(Boolean a);
 
 void cd_get_text_edit_str(short dlog_num, char *str);

--- a/src/Windows Code Release 3/PC editor/graphics.cpp
+++ b/src/Windows Code Release 3/PC editor/graphics.cpp
@@ -320,6 +320,7 @@ void draw_main_screen()
 	RECT top_pic_from = {3,16,41,54};
 
 
+	// TODO: Oddity: should probably be changed to 1, but currently benign
 	paint_pattern(NULL,3,whole_win_rect,3);
 
 	dest_rec = source_rect = title_from;
@@ -412,8 +413,8 @@ void draw_items(short clear_first)
 
 	if (clear_first == 1) {
 		for (i = 0; i < 24; i++)
-			paint_pattern(NULL,1,item_string_rects[i][0],3);
-		paint_pattern(NULL,1,dest_rect,3);
+			paint_pattern_main(item_string_rects[i][0],3);
+		paint_pattern_main(dest_rect,3);
 		}
 	
 	// frame_dlog_rect(mainPtr,frame_rect,0);
@@ -473,10 +474,10 @@ void display_party(short mode,short clear_first)
 	c[3] = GetNearestPaletteIndex(hpal,colors[3]);
 	if (clear_first == 1) { // first erase what's already there
 		for (i = 0; i < 6; i++)
-			paint_pattern(NULL,1,pc_area_buttons[i][0],3);
-		paint_pattern(NULL,1,name_rect,3);
-		paint_pattern(NULL,1,pc_race_rect,3);
-		paint_pattern(NULL,1,info_area_rect,3);
+			paint_pattern_main(pc_area_buttons[i][0],3);
+		paint_pattern_main(name_rect,3);
+		paint_pattern_main(pc_race_rect,3);
+		paint_pattern_main(info_area_rect,3);
 		frame_dlog_rect(mainPtr,pc_info_rect,0); // re-draw the frame
 	}
 
@@ -818,7 +819,7 @@ void display_party(short mode,short clear_first)
 		for(i = 0; i < 5; i++) 
 			if ((current_pressed_button < 0) || (current_pressed_button == i + 10)) {	
 			if (clear_first == 1) { // first erase what's already there
-				paint_pattern(NULL,1,edit_rect[i][0],3);
+				paint_pattern_main(edit_rect[i][0],3);
 				}		
 			//frame_dlog_rect((GrafPtr) mainPtr,edit_rect[i][0],0);
 			//frame_dlog_rect((GrafPtr) mainPtr,edit_rect[i][1],0);

--- a/src/Windows Code Release 3/PC editor/graphics.cpp
+++ b/src/Windows Code Release 3/PC editor/graphics.cpp
@@ -442,8 +442,8 @@ void draw_items(short clear_first)
 			char_win_draw_string(main_dc,item_string_rects[i][0],(char *) to_draw,0,10);
 
 			//Draw id/drop buttons
-			rect_draw_some_item(mixed_gworld,d_from,mixed_gworld,item_string_rects[i][1],1,1);
-			rect_draw_some_item(mixed_gworld,i_from,mixed_gworld,item_string_rects[i][2],1,1);
+			rect_draw_some_item_bmp(mixed_gworld,d_from,mixed_gworld,item_string_rects[i][1],1,1);
+			rect_draw_some_item_bmp(mixed_gworld,i_from,mixed_gworld,item_string_rects[i][2],1,1);
 			}
 	frame_dlog_rect(mainPtr,pc_info_rect,0); // re draw entire frame
 	frame_dlog_rect(mainPtr,name_rect,0); // draw the frame
@@ -506,7 +506,7 @@ void display_party(short mode,short clear_first)
 				from_rect = (current_pressed_button == i) ? ed_buttons_from[1] : ed_buttons_from[0];
 
 				if ((current_pressed_button < 0) || (current_pressed_button == i))
-					rect_draw_some_item(buttons_gworld,from_rect,buttons_gworld,pc_area_buttons[i][0],0,1);
+					rect_draw_some_item_bmp(buttons_gworld,from_rect,buttons_gworld,pc_area_buttons[i][0],0,1);
 				SetTextColor(main_dc,PALETTEINDEX(c[0]));
 				
 				// pc_record_type adven[6] is the records that contains chaarcters
@@ -515,7 +515,7 @@ void display_party(short mode,short clear_first)
 					from_rect = from_base;
 					// draw PC graphic
 					OffsetRect(&from_rect,56 * (adven[i].which_graphic / 8),36 * (adven[i].which_graphic % 8));
-					rect_draw_some_item(pc_gworld,from_rect,pc_gworld,pc_area_buttons[i][1],0,1);
+					rect_draw_some_item_bmp(pc_gworld,from_rect,pc_gworld,pc_area_buttons[i][1],0,1);
 					frame_dlog_rect(mainPtr,pc_area_buttons[i][1],0); // re-draw the frame
 
 					//frame_dlog_rect((GrafPtr) mainPtr,pc_area_buttons[i][1],0); 
@@ -823,7 +823,7 @@ void display_party(short mode,short clear_first)
 			//frame_dlog_rect((GrafPtr) mainPtr,edit_rect[i][0],0);
 			//frame_dlog_rect((GrafPtr) mainPtr,edit_rect[i][1],0);
 			from_rect = (current_pressed_button == i + 10) ? ed_buttons_from[1] : ed_buttons_from[0];
-			rect_draw_some_item(buttons_gworld,from_rect,buttons_gworld,edit_rect[i][0],0,1);
+			rect_draw_some_item_bmp(buttons_gworld,from_rect,buttons_gworld,edit_rect[i][0],0,1);
 			SetTextColor(main_dc,PALETTEINDEX(c[3]));
 			switch(i) {
 				case 0:

--- a/src/Windows Code Release 3/PC editor/graphutl.cpp
+++ b/src/Windows Code Release 3/PC editor/graphutl.cpp
@@ -665,7 +665,7 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 				for (j = 0; j < 4; j++) {
 					pat_dest = pat_dest_orig;
 					OffsetRect(&pat_dest,64 * i, 64 * j);
-					rect_draw_some_item(mixed_gworld,pattern_source,
+					rect_draw_some_item_bmp(mixed_gworld,pattern_source,
 						dialog_pattern_gworld,pat_dest,0,0);
 					}
 			}
@@ -680,7 +680,7 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 					for (j = 0; j < 4; j++) {
 						pat_dest = pat_dest_orig;
 						OffsetRect(&pat_dest,64 * i, 64 * j);
-						rect_draw_some_item(mixed_gworld,pattern_source,
+						rect_draw_some_item_bmp(mixed_gworld,pattern_source,
 							pattern_gworld,pat_dest,0,0);
 						}
 				}
@@ -701,13 +701,13 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 				OffsetRect(&draw_from, -192 * i, -256 * j);
 				switch (which_mode) {
 					case 0:
-						rect_draw_some_item(source_pat,draw_from,
+						rect_draw_some_item_bmp(source_pat,draw_from,
 							dest,draw_to,0,0); break;
 					case 1:
-						rect_draw_some_item(source_pat,draw_from,
+						rect_draw_some_item_bmp(source_pat,draw_from,
 							source_pat,draw_to,0,1); break;
 					case 2:
-						rect_draw_some_item(source_pat,draw_from,
+						rect_draw_some_item_bmp(source_pat,draw_from,
 							dest,draw_to,0,2); break;
 					}
 				}

--- a/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
+++ b/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
@@ -1387,7 +1387,7 @@ void cd_erase_item(short dlog_num, short item_num)
 	Rectangle(win_dc,to_fry.left, to_fry.top,to_fry.right,to_fry.bottom);
 	SelectObject(win_dc,old_brush);
 	SelectObject(win_dc,old_pen);  */
-	paint_pattern(win_dc,2,to_fry,0);
+	paint_pattern_dc(win_dc,to_fry,0);
 	cd_kill_dc(dlg_index,win_dc);  
 
 
@@ -1412,7 +1412,7 @@ void cd_erase_rect(short dlog_num,RECT to_fry)
 	Rectangle(win_dc,to_fry.left, to_fry.top,to_fry.right,to_fry.bottom);
 	SelectObject(win_dc,old_brush);
 	SelectObject(win_dc,old_pen);  */
-	paint_pattern(win_dc,2,to_fry,0);
+	paint_pattern_dc(win_dc,to_fry,0);
 	cd_kill_dc(dlg_index,win_dc);
 
 	//	paint_pattern(dlgs[dlg_index],2,to_fry,0);
@@ -1716,7 +1716,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			rect.top -= 3;
 			rect.right += 3;
 			rect.bottom += 4;
-			paint_pattern(hdc,2,rect,0);
+			paint_pattern_dc(hdc,rect,0);
 
 			//old_brush = SelectObject(hdc,bg[5]);
 			//Rectangle(hdc,rect.left,rect.top,rect.right,rect.bottom);

--- a/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
+++ b/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
@@ -1202,8 +1202,8 @@ void cd_draw_item(short dlog_num,short item_num)
 				case 5:
 					if (item_flag[item_index] == -1)
 						cd_erase_item(dlog_num,item_num);
-						else draw_dialog_graphic(dlgs[dlg_index], item_rect[item_index],
-							item_flag[item_index],(item_flag[item_index] >= 2000) ? FALSE : TRUE,0);
+						else draw_dialog_graphic_wnd(dlgs[dlg_index], item_rect[item_index],
+							item_flag[item_index],(item_flag[item_index] >= 2000) ? FALSE : TRUE);
 					break;
 				}
 			}

--- a/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
+++ b/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
@@ -1135,7 +1135,7 @@ void cd_draw_item(short dlog_num,short item_num)
 					from_rect.left = button_ul_x[button_type[item_flag[item_index]]];
 					from_rect.bottom = from_rect.top + button_height[button_type[item_flag[item_index]]];
 					from_rect.right = from_rect.left + button_width[button_type[item_flag[item_index]]];
-					rect_draw_some_item(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+					rect_draw_some_item_dc(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 					SelectObject(win_dc,bold_font);
 					SetTextColor(win_dc,PALETTEINDEX(c[2]));
@@ -1164,7 +1164,7 @@ void cd_draw_item(short dlog_num,short item_num)
 						}
 					from_rect.right = from_rect.left + 14;
 					from_rect.bottom = from_rect.top + 10;
-					rect_draw_some_item( dlg_buttons_gworld,from_rect, win_dc,item_rect[item_index],0,2); break;
+					rect_draw_some_item_dc( dlg_buttons_gworld,from_rect, win_dc,item_rect[item_index],0,2); break;
 					break;
 
 				case 3: case 4: case 7: case 8: case 9:
@@ -1444,7 +1444,7 @@ void cd_press_button(short dlog_num, short item_num)
 					from_rect.bottom = from_rect.top + button_height[item_flag[item_index]];
 					from_rect.right = from_rect.left + button_width[item_flag[item_index]];
 	OffsetRect(&from_rect,button_width[item_flag[item_index]],0);
-	rect_draw_some_item(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 	if (play_sounds == TRUE) {
 		play_sound(37);
@@ -1453,7 +1453,7 @@ void cd_press_button(short dlog_num, short item_num)
 		else Delay(14,&dummy);
 
 	OffsetRect(&from_rect,-1 * button_width[item_flag[item_index]],0);
-	rect_draw_some_item(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 	*/
 	
 	from_rect.top = button_ul_y[button_type[item_flag[item_index]]];
@@ -1462,7 +1462,7 @@ void cd_press_button(short dlog_num, short item_num)
 	from_rect.right = from_rect.left + button_width[button_type[item_flag[item_index]]];
 	OffsetRect(&from_rect,button_width[button_type[item_flag[item_index]]],0);
 	
-	rect_draw_some_item(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 	SelectObject(win_dc,bold_font);
 	SetTextColor(win_dc,PALETTEINDEX(c[2]));
@@ -1486,7 +1486,7 @@ void cd_press_button(short dlog_num, short item_num)
 		}
 
 	OffsetRect(&from_rect,-1 * button_width[button_type[item_flag[item_index]]],0);
-	rect_draw_some_item(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 	SelectObject(win_dc,bold_font);
 	SetTextColor(win_dc,PALETTEINDEX(c[1]));
@@ -1737,7 +1737,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				rect.left += 1;
 				rect.right = rect.left + 28;
 				}
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP) (hDlg): hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;
@@ -1749,7 +1749,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				}
 			from_gworld = load_pict(820);
 			from_rect = calc_rect(4 * (which_g / 5), which_g % 5);
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;
@@ -1769,8 +1769,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 					SelectObject(hdc,old_brush);
 					}
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0,draw_dest);
 				}
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 1)) {
 				rect.right = rect.left + 28; rect.bottom = rect.top + 36;
@@ -1785,8 +1785,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,rect.left,rect.top + 7);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
@@ -1794,8 +1794,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 				}
 			if ((m_pic_index_x[which_g] == 1) && (m_pic_index_y[which_g] == 2)) {
 				rect.right = rect.left + 28; rect.bottom = rect.top + 36;
@@ -1810,8 +1810,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,rect.left + 7,rect.top);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
@@ -1819,8 +1819,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,0,18);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 				}
 
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 2)) {
@@ -1836,8 +1836,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,rect.left,rect.top);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
@@ -1846,8 +1846,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,14,0);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 
 				m_start_pic = m_pic_index[which_g] + 2;
 				from_gworld = monst_gworld[m_start_pic / 20];
@@ -1856,8 +1856,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,-14,18);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 				m_start_pic = m_pic_index[which_g] + 3;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
@@ -1865,8 +1865,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,14,0);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 				}
 
 			break;
@@ -1897,7 +1897,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 					from_rect = tiny_obj_rect;
 					OffsetRect(&from_rect,18 * (which_g % 10), 18 * (which_g / 10));
 					}
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,to_rect,1,draw_dest);
 			break;
 
@@ -1905,7 +1905,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				which_g -= 700;
 			from_gworld = dlogpics_gworld;
 			OffsetRect(&from2,36 * (which_g % 4),36 * (which_g / 4));
-			rect_draw_some_item(from_gworld,from2,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from2,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			break;
 
@@ -1915,21 +1915,21 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			from_rect = face_from;
 			OffsetRect(&from_rect,32 * ((which_g - 1) % 10),32 * ((which_g - 1) / 10));
 			if (win_or_gworld == 1)
-				 rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,rect,0,0);
-				else rect_draw_some_item(from_gworld,from_rect,hdc,rect,0,draw_dest);
+				 rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
+				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0,draw_dest);
 			break;
 		case 11: // item info help
 			from_rect = item_info_from;
 			rect.right = rect.left + from_rect.right - from_rect.left;
 			rect.bottom = rect.top + from_rect.bottom - from_rect.top;
-			rect_draw_some_item(mixed_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			break;
 		case 12: // item info help
 			from_rect = pc_info_from;
 			rect.right = rect.left + pc_info_from.right - pc_info_from.left;
 			rect.bottom = rect.top + pc_info_from.bottom - pc_info_from.top;
-			rect_draw_some_item(mixed_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			break;
 		case 16:
@@ -1940,7 +1940,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			OffsetRect(&from_rect,32 * (which_g % 5),32 * (which_g / 5));
 			rect.right = rect.left + 32;
 			rect.bottom = rect.top + 32;
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			DisposeGWorld(from_gworld);
 			break;

--- a/src/Windows Code Release 3/Scen Ed/dlogtool.h
+++ b/src/Windows Code Release 3/Scen Ed/dlogtool.h
@@ -43,7 +43,13 @@ short cd_get_item_id(short dlg_num, short item_num);
 void center_window(HWND window);
 RECT get_item_rect(HWND hDlg, short item_num);
 void frame_dlog_rect(HWND hDlg, RECT rect, short val);
-void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld)   ;
+void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld);
+
+inline void draw_dialog_graphic_wnd(HWND hDlg, RECT rect, short which_g, Boolean do_frame)
+{
+	draw_dialog_graphic(hDlg, rect, which_g, do_frame, 0);
+}
+
 void showcursor(Boolean a);
 
 void cd_get_text_edit_str(short dlog_num, char *str);

--- a/src/Windows Code Release 3/Scen Ed/graphics.cpp
+++ b/src/Windows Code Release 3/Scen Ed/graphics.cpp
@@ -169,7 +169,7 @@ void run_startup_g()
 
 	pat_rect = windRect;
 	InflateRect(&pat_rect,500,500);
-//	paint_pattern(NULL,1,pat_rect,3);
+//	paint_pattern_main(pat_rect,3);
 	old_brush = SelectObject(main_dc,GetStockObject(BLACK_BRUSH));
 	Rectangle(main_dc, pat_rect.left,pat_rect.top,
 		pat_rect.right,pat_rect.bottom);
@@ -243,7 +243,7 @@ void redraw_screen()
 
 	pat_rect = windRect;
 	InflateRect(&pat_rect,500,500);
-	paint_pattern(NULL,1,pat_rect,3);
+	paint_pattern_main(pat_rect,3);
 	draw_main_screen();
 	if (overall_mode < 60);
 		draw_terrain();
@@ -281,7 +281,7 @@ void draw_main_screen()
 
 		InsetRect(&draw_rect,1,1);
 		OffsetRect(&draw_rect,-1 * ulx,-1 * uly);
-		paint_pattern(NULL,1,draw_rect,3);
+		paint_pattern_main(draw_rect,3);
 
 		draw_rb();
 
@@ -308,7 +308,7 @@ void draw_lb()
 	temp_rect = windRect;
 	temp_rect.right = RIGHT_AREA_UL_X - 2;
 	//FillCRECT(&temp_rect,bg[12]);
-	paint_pattern(NULL,1,temp_rect,3);
+	paint_pattern_main(temp_rect,3);
 	for (i = 0; i < NLS; i++)
 		draw_lb_slot(i,0);
 }
@@ -324,7 +324,7 @@ void draw_lb_slot (short which,short mode)
 	c2 = GetNearestPaletteIndex(hpal,colors2);
  	//FillCRECT(&left_buttons[which][0],bg[12]);
 	
-	paint_pattern(NULL,1,left_buttons[which][0],3);
+	paint_pattern_main(left_buttons[which][0],3);
 	if (left_button_status[which] == 0)
 		return;
 	text_rect = left_buttons[which][0];
@@ -380,7 +380,7 @@ void draw_rb_slot (short which,short mode)
 	text_rect = right_buttons[which - pos];
 	text_rect.right += 2;
    text_rect.bottom += 2;
-	paint_pattern(NULL,1,text_rect,1);
+	paint_pattern_main(text_rect,1);
 	text_rect.bottom -= 2;
 	if (right_button_status[which] == 0)
 		return;
@@ -404,7 +404,7 @@ void set_up_terrain_buttons()
 	UINT c;
 	HBRUSH new_brush;
 			
-	paint_pattern(terrain_buttons_gworld,0,terrain_buttons_rect,1);
+	paint_pattern_bmp(terrain_buttons_gworld,terrain_buttons_rect,1);
 	
 	hdc = CreateCompatibleDC(main_dc);
 	//store_text_hdc = hdc;
@@ -517,7 +517,7 @@ void draw_terrain()
 		return;
 
 	if (cur_viewing_mode == 0) {
-		paint_pattern(ter_draw_gworld,0,terrain_rect,1);
+		paint_pattern_bmp(ter_draw_gworld,terrain_rect,1);
 		}
 	hdc = CreateCompatibleDC(main_dc);
 	//store_text_hdc = hdc;
@@ -736,7 +736,7 @@ void draw_terrain()
 	if (cur_viewing_mode == 1) {
 		if (small_any_drawn == FALSE) {
 			InsetRect(&terrain_rect,1,1);
-			paint_pattern(ter_draw_gworld,0,terrain_rect,1);
+			paint_pattern_bmp(ter_draw_gworld,terrain_rect,1);
 			InsetRect(&terrain_rect,-1,-1);
 			//FrameRect(&terrain_rect);
 			}
@@ -1121,12 +1121,12 @@ void place_location()
 	erase_rect.right = RIGHT_AREA_WIDTH - 1;
 	erase_rect.top = terrain_rects[255].top + 12 - 10;
 	erase_rect.bottom = erase_rect.top + 12;
-	paint_pattern(terrain_buttons_gworld,0,erase_rect,1);
+	paint_pattern_bmp(terrain_buttons_gworld,erase_rect,1);
 	erase_rect.left = 2;
 	erase_rect.right = RIGHT_AREA_WIDTH - 1;
 	erase_rect.top = terrain_rects[255].bottom + 117;
 	erase_rect.bottom = RIGHT_AREA_HEIGHT + 6;
-	paint_pattern(terrain_buttons_gworld,0,erase_rect,1);
+	paint_pattern_bmp(terrain_buttons_gworld,erase_rect,1);
 
 	hdc = CreateCompatibleDC(main_dc);
 	//store_text_hdc = hdc;
@@ -1219,7 +1219,7 @@ void place_just_location()
 	erase_rect.right = RIGHT_AREA_WIDTH - 1;
 	erase_rect.top = terrain_rects[255].top + 12 - 9;
 	erase_rect.bottom = erase_rect.top + 12;
-	paint_pattern(terrain_buttons_gworld,0,erase_rect,1);
+	paint_pattern_bmp(terrain_buttons_gworld,erase_rect,1);
 
 	hdc = CreateCompatibleDC(main_dc);
 	//store_text_hdc = hdc;

--- a/src/Windows Code Release 3/Scen Ed/graphics.cpp
+++ b/src/Windows Code Release 3/Scen Ed/graphics.cpp
@@ -178,7 +178,7 @@ void run_startup_g()
 	start_g = load_pict(3002);
 	to_rect = pict_rect;
 	OffsetRect(&to_rect,-18,-30);
-	rect_draw_some_item(start_g,pict_rect,start_g,to_rect,0,1);
+	rect_draw_some_item_bmp(start_g,pict_rect,start_g,to_rect,0,1);
 	DeleteObject(start_g);
 	play_sound(95);
 
@@ -232,7 +232,7 @@ void load_main_screen()
 		map_from = map_from_orig;
 		OffsetRect(&map_from,8 * (i / 10),8 * (i % 10));
 		map_bitmap[i] = CreateCompatibleBitmap(main_dc,8,8);
-		rect_draw_some_item(mixed_gworld,map_from,map_bitmap[i],brush_to,0,0);
+		rect_draw_some_item_bmp(mixed_gworld,map_from,map_bitmap[i],brush_to,0,0);
 		map_brush[i] = CreatePatternBrush(map_bitmap[i]);
 		}
 }
@@ -292,7 +292,7 @@ void draw_main_screen()
 	if ((overall_mode < 60) || (overall_mode == 62)) {
 		//draw_rect = terrain_buttons_rect;
 		//OffsetRect(&draw_rect,RIGHT_AREA_UL_X,RIGHT_AREA_UL_Y);
-		//rect_draw_some_item(terrain_buttons_gworld,terrain_buttons_rect,
+		//rect_draw_some_item_bmp(terrain_buttons_gworld,terrain_buttons_rect,
 		//	terrain_buttons_gworld,draw_rect,0,1);
 		place_location();
 		}
@@ -333,7 +333,7 @@ void draw_lb_slot (short which,short mode)
 		from_rect = blue_button_from;
 		if (mode > 0)
 			OffsetRect(&from_rect,from_rect.right - from_rect.left,0);
-		rect_draw_some_item(editor_mixed,from_rect,editor_mixed,left_buttons[which][1],0,1);
+		rect_draw_some_item_bmp(editor_mixed,from_rect,editor_mixed,left_buttons[which][1],0,1);
 		}
 	if (left_button_status[which] % 10 == 3) 
 		text_rect.left += 16;
@@ -436,13 +436,13 @@ void set_up_terrain_buttons()
 		pic = scenario.ter_types[i].picture;
 		if (pic >= 1000) {
 			ter_from = get_custom_rect(pic % 1000);
-			rect_draw_some_item(spec_scen_g,
+			rect_draw_some_item_bmp(spec_scen_g,
 				ter_from,terrain_buttons_gworld,terrain_rects[i],0,0);
 			}
 		else if (pic < 400)	{
 				pic = pic % 50;
 				OffsetRect(&ter_from,28 * (pic % 10), 36 * (pic / 10));
-				rect_draw_some_item(terrain_gworld[scenario.ter_types[i].picture/50],
+				rect_draw_some_item_bmp(terrain_gworld[scenario.ter_types[i].picture/50],
 					ter_from,terrain_buttons_gworld,terrain_rects[i],0,0);
 				}
 				else if (pic < 1000) {
@@ -452,7 +452,7 @@ void set_up_terrain_buttons()
 					ter_from.top = 36 * (pic % 5);
 					ter_from.bottom = ter_from.top + 36;
 
-					rect_draw_some_item(anim_gworld,
+					rect_draw_some_item_bmp(anim_gworld,
 						ter_from,terrain_buttons_gworld,terrain_rects[i],0,0);
 					}
 		small_i = small_icons[scenario.ter_types[i].special];
@@ -472,7 +472,7 @@ void set_up_terrain_buttons()
 		tiny_to.top = tiny_to.bottom - 7;
 		tiny_to.left = tiny_to.right - 7;
 		if (small_i > 0) {
-			rect_draw_some_item(editor_mixed,
+			rect_draw_some_item_bmp(editor_mixed,
 				tiny_from,terrain_buttons_gworld,tiny_to,0,0);
 			}
 		}
@@ -490,7 +490,7 @@ void set_up_terrain_buttons()
 				}
 		palette_to.right = palette_to.left + palette_from.right;
 		palette_to.bottom = palette_to.top + palette_from.bottom;
-		rect_draw_some_item(editor_mixed,
+		rect_draw_some_item_bmp(editor_mixed,
 			palette_from,terrain_buttons_gworld,palette_to,1,0);
 		}
 
@@ -566,7 +566,7 @@ void draw_terrain()
 				from_rect = start_button_from;
 				to_rect = tiny_to;
 				to_rect.left -= 14;
-				rect_draw_some_item(editor_mixed,from_rect,ter_draw_gworld,to_rect,0,0);
+				rect_draw_some_item_bmp(editor_mixed,from_rect,ter_draw_gworld,to_rect,0,0);
 				OffsetRect(&tiny_to,0,-7);
 				}
 			if ((editing_town == FALSE)
@@ -577,7 +577,7 @@ void draw_terrain()
 				from_rect = start_button_from;
 				to_rect = tiny_to;
 				to_rect.left -= 14;
-				rect_draw_some_item(editor_mixed,from_rect,ter_draw_gworld,to_rect,0,0);
+				rect_draw_some_item_bmp(editor_mixed,from_rect,ter_draw_gworld,to_rect,0,0);
 				OffsetRect(&tiny_to,0,-7);
 				}
 			small_i = small_icons[scenario.ter_types[t_to_draw].special];
@@ -588,20 +588,20 @@ void draw_terrain()
 			tiny_from = base_small_button_from;
 			OffsetRect(&tiny_from,7 * (small_i % 10),7 * (small_i / 10));
 			if (small_i > 0) {
-				rect_draw_some_item(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
+				rect_draw_some_item_bmp(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
 				OffsetRect(&tiny_to,0,-7);
 				}
 
 				if (is_special(cen_x + q - 4,cen_y + r - 4) == TRUE) {
 					tiny_from = base_small_button_from;
 					OffsetRect(&tiny_from,7 * (7),7 * (0));
-					rect_draw_some_item(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
+					rect_draw_some_item_bmp(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
 					OffsetRect(&tiny_to,0,-7);
 					}
 				if ((t_to_draw == 7) || (t_to_draw == 10) || (t_to_draw == 13) || (t_to_draw == 16)) {
 					tiny_from = base_small_button_from;
 					OffsetRect(&tiny_from,7 * (3),7 * (2));
-					rect_draw_some_item(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
+					rect_draw_some_item_bmp(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
 					OffsetRect(&tiny_to,0,-7);
 					}
 				//if (is_s_d(cen_x + q - 4,cen_y + r - 4) == TRUE) {
@@ -612,7 +612,7 @@ void draw_terrain()
 							(cen_y + r - 4 == current_terrain.wandering_locs[i].y)) {
 							tiny_from = base_small_button_from;
 							OffsetRect(&tiny_from,7 * (2),7 * (1));
-							rect_draw_some_item(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
+							rect_draw_some_item_bmp(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
 							OffsetRect(&tiny_to,0,-7);
 							i = 4;
 							}
@@ -625,7 +625,7 @@ void draw_terrain()
 							(cen_y + r - 4 == town.start_locs[i].y)) {
 							tiny_from = base_small_button_from;
 							OffsetRect(&tiny_from,7 * (6 + i),7 * (1));
-							rect_draw_some_item(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
+							rect_draw_some_item_bmp(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
 							OffsetRect(&tiny_to,0,-7);
 							}
 					for (i = 0; i < 4; i++)
@@ -633,7 +633,7 @@ void draw_terrain()
 							(cen_y + r - 4 == town.wandering_locs[i].y)) {
 							tiny_from = base_small_button_from;
 							OffsetRect(&tiny_from,7 * (2),7 * (1));
-							rect_draw_some_item(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
+							rect_draw_some_item_bmp(editor_mixed,tiny_from,ter_draw_gworld,tiny_to,0,0);
 							OffsetRect(&tiny_to,0,-7);
 							i = 4;
 							}
@@ -759,7 +759,7 @@ void draw_terrain()
 
 	//to_rect = world_screen;
 	//OffsetRect(&to_rect,TER_RECT_UL_X,TER_RECT_UL_Y);
-	rect_draw_some_item(ter_draw_gworld,terrain_rect,ter_draw_gworld,world_screen,0,1);
+	rect_draw_some_item_bmp(ter_draw_gworld,terrain_rect,ter_draw_gworld,world_screen,0,1);
 }
 
 void draw_monsts(HDC hdc)
@@ -847,7 +847,7 @@ void draw_items(HDC hdc)
 					if (pic_num >= 150) {
 						source_rect = get_custom_rect(pic_num - 150);
 						draw_rect = calc_rect(where_draw.x,where_draw.y);
-						rect_draw_some_item(spec_scen_g,
+						rect_draw_some_item_bmp(spec_scen_g,
 							 source_rect, ter_draw_gworld, draw_rect, 1, 0);
   						}
 						else {
@@ -860,7 +860,7 @@ void draw_items(HDC hdc)
 								draw_rect.left += 5;
 								draw_rect.right -= 5;
 								}
-							rect_draw_some_item((pic_num < 45) ? items_gworld : tiny_obj_gworld,
+							rect_draw_some_item_bmp((pic_num < 45) ? items_gworld : tiny_obj_gworld,
 							 source_rect, ter_draw_gworld, draw_rect, 1, 0);
 							}
 					}
@@ -954,7 +954,7 @@ void draw_one_tiny_terrain_spot (short i,short j,unsigned char terrain_to_draw,H
 			}
 		else if (picture_wanted >= 1000)	{
 			from_rect = get_custom_rect(picture_wanted % 1000);
-			rect_draw_some_item(spec_scen_g, from_rect, ter_draw_gworld, dest_rect, 0, 0);
+			rect_draw_some_item_bmp(spec_scen_g, from_rect, ter_draw_gworld, dest_rect, 0, 0);
 			}
 		else if (picture_wanted >= 400)	{
 				source_gworld = anim_gworld;
@@ -994,9 +994,9 @@ void draw_one_tiny_terrain_spot (short i,short j,unsigned char terrain_to_draw,H
 									163 + 6 * (picture_wanted % 5) + 1);
 		 			SelectObject(hdc,store_bmp);
 					dest_rect.right--; dest_rect.bottom--;
-					rect_draw_some_item(mixed_gworld, from_rect, ter_draw_gworld, dest_rect, 0, 0);
+					rect_draw_some_item_bmp(mixed_gworld, from_rect, ter_draw_gworld, dest_rect, 0, 0);
 					store_bmp = SelectObject(hdc,ter_draw_gworld);
-					//rect_draw_some_item(source_gworld, source_rect, ter_draw_gworld, dest_rect, 0, 0);
+					//rect_draw_some_item_bmp(source_gworld, source_rect, ter_draw_gworld, dest_rect, 0, 0);
 					}
 			}
 			else {
@@ -1008,7 +1008,7 @@ void draw_one_tiny_terrain_spot (short i,short j,unsigned char terrain_to_draw,H
 
 				SelectObject(hdc,store_bmp);
 				dest_rect.right--; dest_rect.bottom--;
-				rect_draw_some_item(mixed_gworld, from_rect, ter_draw_gworld, dest_rect, 0, 0);
+				rect_draw_some_item_bmp(mixed_gworld, from_rect, ter_draw_gworld, dest_rect, 0, 0);
 				store_bmp = SelectObject(hdc,ter_draw_gworld);
 			}
 		break;
@@ -1034,7 +1034,7 @@ RECT	destrec;
 	destrec.left = destrec.right - (src_rect.right - src_rect.left);
 	destrec.top = destrec.bottom - (src_rect.bottom - src_rect.top);
 
-	rect_draw_some_item(src_gworld,src_rect,ter_draw_gworld,destrec,masked,0);
+	rect_draw_some_item_bmp(src_gworld,src_rect,ter_draw_gworld,destrec,masked,0);
 
 }
 
@@ -1178,7 +1178,7 @@ void place_location()
 	if (overall_mode < 60) {
 		if (picture_wanted >= 1000)	{
 			source_rect = get_custom_rect(picture_wanted % 1000);
-			rect_draw_some_item(spec_scen_g,
+			rect_draw_some_item_bmp(spec_scen_g,
 				source_rect,terrain_buttons_gworld,draw_rect,0,0);
  			}
 			else if (picture_wanted >= 400)	{
@@ -1187,18 +1187,18 @@ void place_location()
 				source_rect.right = source_rect.left + 28;
 				source_rect.top = 36 * (picture_wanted % 5);
 				source_rect.bottom = source_rect.top + 36;
-				rect_draw_some_item(anim_gworld,source_rect,terrain_buttons_gworld,draw_rect,0,0);
+				rect_draw_some_item_bmp(anim_gworld,source_rect,terrain_buttons_gworld,draw_rect,0,0);
 				}
 				else {
 					source_rect = get_template_rect(current_terrain_type);
-					rect_draw_some_item(terrain_gworld[picture_wanted / 50],source_rect,
+					rect_draw_some_item_bmp(terrain_gworld[picture_wanted / 50],source_rect,
 						terrain_buttons_gworld,draw_rect,0,0);
 					}
 		}
 
 	draw_rect = terrain_buttons_rect;
 	OffsetRect(&draw_rect,RIGHT_AREA_UL_X,RIGHT_AREA_UL_Y);
-	rect_draw_some_item(terrain_buttons_gworld,terrain_buttons_rect,
+	rect_draw_some_item_bmp(terrain_buttons_gworld,terrain_buttons_rect,
 		terrain_buttons_gworld,draw_rect,0,1);
 }
 
@@ -1249,7 +1249,7 @@ void place_just_location()
 	from_rect.bottom = erase_rect.bottom;
 	draw_rect = from_rect;
 	OffsetRect(&draw_rect,RIGHT_AREA_UL_X,RIGHT_AREA_UL_Y);
-	rect_draw_some_item(terrain_buttons_gworld,from_rect,
+	rect_draw_some_item_bmp(terrain_buttons_gworld,from_rect,
 		terrain_buttons_gworld,draw_rect,0,1);
 	DeleteObject(hdc);
 }
@@ -1277,7 +1277,7 @@ void draw_cur_string()
 	from_rect.top = from_rect.bottom - 40;
 	draw_rect = from_rect;
 	OffsetRect(&draw_rect,RIGHT_AREA_UL_X,RIGHT_AREA_UL_Y);
-	rect_draw_some_item(terrain_buttons_gworld,from_rect,
+	rect_draw_some_item_bmp(terrain_buttons_gworld,from_rect,
 		terrain_buttons_gworld,draw_rect,0,1);
 	MoveTo(RIGHT_AREA_UL_X + 5,terrain_rects[255].bottom + 120);
 	DrawString(current_string);

--- a/src/Windows Code Release 3/Scen Ed/graphutl.cpp
+++ b/src/Windows Code Release 3/Scen Ed/graphutl.cpp
@@ -696,7 +696,7 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 				for (j = 0; j < 4; j++) {
 					pat_dest = pat_dest_orig;
 					OffsetRect(&pat_dest,64 * i, 64 * j);
-					rect_draw_some_item(mixed_gworld,pattern_source,
+					rect_draw_some_item_bmp(mixed_gworld,pattern_source,
 						dialog_pattern_gworld,pat_dest,0,0);
 					}
 			}
@@ -711,7 +711,7 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 					for (j = 0; j < 4; j++) {
 						pat_dest = pat_dest_orig;
 						OffsetRect(&pat_dest,64 * i, 64 * j);
-						rect_draw_some_item(mixed_gworld,pattern_source,
+						rect_draw_some_item_bmp(mixed_gworld,pattern_source,
 							pattern_gworld,pat_dest,0,0);
 						}
 				}
@@ -732,13 +732,13 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 				OffsetRect(&draw_from, -192 * i, -256 * j);
 				switch (which_mode) {
 					case 0:
-						rect_draw_some_item(source_pat,draw_from,
+						rect_draw_some_item_bmp(source_pat,draw_from,
 							dest,draw_to,0,0); break;
 					case 1:
-						rect_draw_some_item(source_pat,draw_from,
+						rect_draw_some_item_bmp(source_pat,draw_from,
 							source_pat,draw_to,0,1); break;
 					case 2:
-						rect_draw_some_item(source_pat,draw_from,
+						rect_draw_some_item_bmp(source_pat,draw_from,
 							dest,draw_to,0,2); break;
 					}
 				}

--- a/src/Windows Code Release 3/dlogtool.cpp
+++ b/src/Windows Code Release 3/dlogtool.cpp
@@ -10,9 +10,11 @@
 
 #include "global.h"
 #include "graphutl.h"
+#include "graphutl_helpers.hpp"
 #include "stdio.h"
 #include "exlsound.h"
 #include "dlogtool.h"
+#include "dlogtool_helpers.hpp"
 #include "text.h"
 #include "locutils.h"
 
@@ -1208,7 +1210,7 @@ void cd_draw_item(short dlog_num,short item_num)
 					from_rect.left = button_ul_x[button_type[item_flag[item_index]]];
 					from_rect.bottom = from_rect.top + button_height[button_type[item_flag[item_index]]];
 					from_rect.right = from_rect.left + button_width[button_type[item_flag[item_index]]];
-					rect_draw_some_item(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+					rect_draw_some_item_dc(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 					SelectObject(win_dc,bold_font);
 					SetTextColor(win_dc,PALETTEINDEX(c[2]));
@@ -1237,7 +1239,7 @@ void cd_draw_item(short dlog_num,short item_num)
 						}
 					from_rect.right = from_rect.left + 14;
 					from_rect.bottom = from_rect.top + 10;
-					rect_draw_some_item( dlg_buttons_gworld,from_rect, win_dc,item_rect[item_index],0,2); break;
+					rect_draw_some_item_dc( dlg_buttons_gworld,from_rect, win_dc,item_rect[item_index],0,2); break;
 					break;
 
 				case 3: case 4: case 7: case 8: case 9:
@@ -1508,7 +1510,7 @@ void cd_press_button(short dlog_num, short item_num)
 					from_rect.bottom = from_rect.top + button_height[item_flag[item_index]];
 					from_rect.right = from_rect.left + button_width[item_flag[item_index]];
 	OffsetRect(&from_rect,button_width[item_flag[item_index]],0);
-	rect_draw_some_item(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 	if (play_sounds == TRUE) {
 		play_sound(37);
@@ -1517,7 +1519,7 @@ void cd_press_button(short dlog_num, short item_num)
 		else Delay(14,&dummy);
 
 	OffsetRect(&from_rect,-1 * button_width[item_flag[item_index]],0);
-	rect_draw_some_item(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlgbtns_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 	*/
 	
 	from_rect.top = button_ul_y[button_type[item_flag[item_index]]];
@@ -1526,7 +1528,7 @@ void cd_press_button(short dlog_num, short item_num)
 	from_rect.right = from_rect.left + button_width[button_type[item_flag[item_index]]];
 	OffsetRect(&from_rect,button_width[button_type[item_flag[item_index]]],0);
 	
-	rect_draw_some_item(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 	SelectObject(win_dc,bold_font);
 	SetTextColor(win_dc,PALETTEINDEX(c[2]));
@@ -1551,7 +1553,7 @@ void cd_press_button(short dlog_num, short item_num)
 		else Delay(10,&dummy);
 
 	OffsetRect(&from_rect,-1 * button_width[button_type[item_flag[item_index]]],0);
-	rect_draw_some_item(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
+	rect_draw_some_item_dc(dlg_buttons_gworld,from_rect,win_dc,item_rect[item_index],0,2);
 
 	SelectObject(win_dc,bold_font);
 	SetTextColor(win_dc,PALETTEINDEX(c[1]));
@@ -1799,7 +1801,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				rect.left += 1;
             rect.right = rect.left + 28;
 				}
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP) (hDlg): hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;
@@ -1807,7 +1809,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			which_g -= 300;
 			from_gworld = load_pict(820,main_dc);
 			from_rect = calc_rect(4 * (which_g / 5), which_g % 5);
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;
@@ -1826,8 +1828,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 					SelectObject(hdc,old_brush);
 					}
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0,draw_dest);
 				DeleteObject(from_gworld);
 				}
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 1)) {
@@ -1843,8 +1845,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,rect.left,rect.top + 7);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
@@ -1854,8 +1856,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,14,0);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 				DeleteObject(from_gworld);
 				}
 			if ((m_pic_index_x[which_g] == 1) && (m_pic_index_y[which_g] == 2)) {
@@ -1872,8 +1874,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,rect.left + 7,rect.top);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
@@ -1882,8 +1884,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,0,18);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 				DeleteObject(from_gworld);
 				}
 
@@ -1900,8 +1902,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,rect.left,rect.top);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
@@ -1911,8 +1913,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,14,0);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 
 				m_start_pic = m_pic_index[which_g] + 2;
 				DeleteObject(from_gworld);
@@ -1922,8 +1924,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,-14,18);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 				m_start_pic = m_pic_index[which_g] + 3;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
@@ -1932,8 +1934,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,14,0);
 
 				if (win_or_gworld == 1)
-					rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
 				}
 				DeleteObject(from_gworld);
 			break;
@@ -1955,14 +1957,14 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 					from_rect = tiny_obj_rect;
 					OffsetRect(&from_rect,18 * (which_g % 10), 18 * (which_g / 10));
 					}
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,to_rect,1,draw_dest);
 			break;
 		case 7: // dialog
 				which_g -= 700;
 			from_gworld = dlogpics_gworld;
 			OffsetRect(&from2,36 * (which_g % 4),36 * (which_g / 4));
-			rect_draw_some_item(from_gworld,from2,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from2,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			break;
 		case 8: // PC
@@ -1975,7 +1977,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			Rectangle(hdc,rect.left,rect.top,rect.right,rect.bottom);
 			SelectObject(hdc,old_brush);
 			//PaintRect(&rect);
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,1,draw_dest);
 			if (pcs_gworld == NULL)
 				DeleteObject(from_gworld);
@@ -1986,8 +1988,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			from_rect = bw_from;
 			OffsetRect(&from_rect,120 * ((which_g) % 3),120 * ((which_g) / 3));
 			if (win_or_gworld == 1)
-				 rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,rect,0,0);
-				else rect_draw_some_item(from_gworld,from_rect,hdc,rect,0,draw_dest);
+				 rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
+				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;
 		case 10: // talk face
@@ -1996,22 +1998,22 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			from_rect = face_from;
 			OffsetRect(&from_rect,32 * ((which_g - 1) % 10),32 * ((which_g - 1) / 10));
 			if (win_or_gworld == 1)
-				 rect_draw_some_item(from_gworld,from_rect,(HBITMAP) hDlg,rect,0,0);
-				else rect_draw_some_item(from_gworld,from_rect,hdc,rect,0,draw_dest);
+				 rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
+				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;
 		case 11: // item info help  
 			from_rect = item_info_from;
 			rect.right = rect.left + from_rect.right - from_rect.left;
 			rect.bottom = rect.top + from_rect.bottom - from_rect.top;
-			rect_draw_some_item(mixed_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			break;
 		case 12: // item info help  
 			from_rect = pc_info_from;
 			rect.right = rect.left + pc_info_from.right - pc_info_from.left;
 			rect.bottom = rect.top + pc_info_from.bottom - pc_info_from.top;
-			rect_draw_some_item(mixed_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			break;
 		case 14: // button help
@@ -2020,7 +2022,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				from_gworld = load_pict(900 + which_g,main_dc);
 				from_rect = large_scen_from;
 				OffsetRect(&from_rect,64 * (which_g % 10),0);
-				rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 				  ,rect,0,draw_dest);
 				DeleteObject(from_gworld);
 				break;
@@ -2031,7 +2033,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			rect.right = rect.left + from_rect.right;
 			rect.bottom = rect.top + from_rect.bottom;
 			OffsetRect(&from_rect,0,100 * which_g);
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;
@@ -2040,7 +2042,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			from_rect = combat_ap_from;
 			rect.right = rect.left + from_rect.right;
 			rect.bottom = rect.top + from_rect.bottom;
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP) (hDlg): hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;
@@ -2049,7 +2051,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			from_rect = stat_symbols_from;
 			rect.right = rect.left + from_rect.right;
 			rect.bottom = rect.top + from_rect.bottom;
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP) (hDlg): hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;
@@ -2061,7 +2063,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			OffsetRect(&from_rect,32 * (which_g % 5),32 * (which_g / 5));
 			rect.right = rect.left + 32;
 			rect.bottom = rect.top + 32;
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP) (hDlg): hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			DeleteObject(from_gworld);
 			break;
@@ -2076,7 +2078,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 
 				//PaintRect(&rect);
 				}
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP)hDlg: hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,0,draw_dest);
 			break;
 		case 20: case 21: case 22: case 23: // dialog
@@ -2091,7 +2093,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				SelectObject(hdc,old_brush);
 				}
 
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP) (hDlg): hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,rect,(do_frame == FALSE) ? 1 : 0,draw_dest);
 			break;
 		case 24: case 25: case 26: case 27: // dialog
@@ -2105,13 +2107,13 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			to_rect.bottom = to_rect.top + square_size;
 			from_rect.right = from_rect.left + square_size / 2;
 			from_rect.bottom = from_rect.top + square_size;
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP) (hDlg): hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,to_rect,1,draw_dest);
 			from_rect = get_custom_rect(which_g + 1);
 			OffsetRect(&to_rect,square_size / 2,0);
 			from_rect.right = from_rect.left + square_size / 2;
 			from_rect.bottom = from_rect.top + square_size;
-			rect_draw_some_item(from_gworld,from_rect,(HBITMAP) ((win_or_gworld == 1) ? (HBITMAP) (hDlg): hdc)
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
 			  ,to_rect,1,draw_dest);
 			break;
 		}

--- a/src/Windows Code Release 3/dlogtool.cpp
+++ b/src/Windows Code Release 3/dlogtool.cpp
@@ -1274,8 +1274,8 @@ void cd_draw_item(short dlog_num,short item_num)
 				case 5:
 					if (item_flag[item_index] == -1)
 						cd_erase_item(dlog_num,item_num);
-						else draw_dialog_graphic(dlgs[dlg_index], item_rect[item_index],
-							item_flag[item_index],(item_flag[item_index] >= 2000) ? FALSE : TRUE,0);
+						else draw_dialog_graphic_wnd(dlgs[dlg_index], item_rect[item_index],
+							item_flag[item_index],(item_flag[item_index] >= 2000) ? FALSE : TRUE);
 					break;
 				}
 			}

--- a/src/Windows Code Release 3/dlogtool.cpp
+++ b/src/Windows Code Release 3/dlogtool.cpp
@@ -1453,7 +1453,7 @@ void cd_erase_item(short dlog_num, short item_num)
 	Rectangle(win_dc,to_fry.left, to_fry.top,to_fry.right,to_fry.bottom);
 	SelectObject(win_dc,old_brush);
 	SelectObject(win_dc,old_pen);  */
-	paint_pattern(win_dc,2,to_fry,0);
+	paint_pattern_dc(win_dc,to_fry,0);
 	cd_kill_dc(dlg_index,win_dc);  
 
 
@@ -1478,7 +1478,7 @@ void cd_erase_rect(short dlog_num,RECT to_fry)
 	Rectangle(win_dc,to_fry.left, to_fry.top,to_fry.right,to_fry.bottom);
 	SelectObject(win_dc,old_brush);
 	SelectObject(win_dc,old_pen);  */
-	paint_pattern(win_dc,2,to_fry,0);
+	paint_pattern_dc(win_dc,to_fry,0);
 	cd_kill_dc(dlg_index,win_dc);
 
 	//	paint_pattern(dlgs[dlg_index],2,to_fry,0);
@@ -1780,7 +1780,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 		}
 	if (which_g == 950) { // Empty. Maybe clear space.
 		if (win_or_gworld == 0) {
-			paint_pattern(hdc,2,rect,0);
+			paint_pattern_dc(hdc,rect,0);
 
 			//old_brush = SelectObject(hdc,bg[5]);
 			//Rectangle(hdc,rect.left,rect.top,rect.right,rect.bottom);

--- a/src/Windows Code Release 3/dlogtool.h
+++ b/src/Windows Code Release 3/dlogtool.h
@@ -41,7 +41,18 @@ short cd_get_item_id(short dlg_num, short item_num);
 void center_window(HWND window);
 RECT get_item_rect(HWND hDlg, short item_num);
 void frame_dlog_rect(HWND hDlg, RECT rect, short val);
-void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld)   ;
+void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld);
+
+inline void draw_dialog_graphic_bmp(HBITMAP hBitmap, RECT rect, short which_g, Boolean do_frame)
+{
+	draw_dialog_graphic(reinterpret_cast<HWND>(hBitmap), rect, which_g, do_frame, 1);
+}
+
+inline void draw_dialog_graphic_wnd(HWND hDlg, RECT rect, short which_g, Boolean do_frame)
+{
+	draw_dialog_graphic(hDlg, rect, which_g, do_frame, 0);
+}
+
 void showcursor(Boolean a);
 
 void cd_get_text_edit_str(short dlog_num, char *str);

--- a/src/Windows Code Release 3/dlogtool.h
+++ b/src/Windows Code Release 3/dlogtool.h
@@ -42,17 +42,6 @@ void center_window(HWND window);
 RECT get_item_rect(HWND hDlg, short item_num);
 void frame_dlog_rect(HWND hDlg, RECT rect, short val);
 void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld);
-
-inline void draw_dialog_graphic_bmp(HBITMAP hBitmap, RECT rect, short which_g, Boolean do_frame)
-{
-	draw_dialog_graphic(reinterpret_cast<HWND>(hBitmap), rect, which_g, do_frame, 1);
-}
-
-inline void draw_dialog_graphic_wnd(HWND hDlg, RECT rect, short which_g, Boolean do_frame)
-{
-	draw_dialog_graphic(hDlg, rect, which_g, do_frame, 0);
-}
-
 void showcursor(Boolean a);
 
 void cd_get_text_edit_str(short dlog_num, char *str);

--- a/src/Windows Code Release 3/dlogtool_helpers.hpp
+++ b/src/Windows Code Release 3/dlogtool_helpers.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+// Stopgap mechanism to reduce the amount of casting to known places only for now
+
+static inline void draw_dialog_graphic_bmp(HBITMAP hBitmap, RECT rect, short which_g, Boolean do_frame)
+{
+	draw_dialog_graphic(reinterpret_cast<HWND>(hBitmap), rect, which_g, do_frame, 1);
+}
+
+static inline void draw_dialog_graphic_wnd(HWND hDlg, RECT rect, short which_g, Boolean do_frame)
+{
+	draw_dialog_graphic(hDlg, rect, which_g, do_frame, 0);
+}

--- a/src/Windows Code Release 3/graphics.cpp
+++ b/src/Windows Code Release 3/graphics.cpp
@@ -346,13 +346,13 @@ void draw_startup(short but_type)
 		return;
 
 	r1.bottom = uly + 5;
-	paint_pattern(NULL,1,r1,0);
+	paint_pattern_main(r1,0);
 	r2.right = ulx + 5;
-	paint_pattern(NULL,1,r2,0);
+	paint_pattern_main(r2,0);
 	r3.top += uly + 5;
-	paint_pattern(NULL,1,r3,0);
+	paint_pattern_main(r3,0);
 	r4.left += ulx + 5;
-	paint_pattern(NULL,1,r4,0);
+	paint_pattern_main(r4,0);
 	to_rect = startup_from[0];
 	OffsetRect(&to_rect,5,5);
 	rect_draw_some_item_bmp(startup_gworld,startup_from[0],startup_gworld,to_rect,0,1);
@@ -986,7 +986,7 @@ void put_background()
 
 	SelectClipRgn(main_dc,clip_region);
 	GetClientRect(mainPtr,&r);
-	paint_pattern(mainPtr, 1,r,wp);
+	paint_pattern_wnd(mainPtr,r,wp);
 	undo_clip();
 
 	//ShowScrollBar(text_sbar,SB_CTL,TRUE);
@@ -1016,7 +1016,7 @@ void flood_bg()
 		}
 
 	GetWindowRect(mainPtr,&r);
-	paint_pattern(NULL, 1,r,wp);
+	paint_pattern_main(r,wp);
 }
 
 void draw_buttons(short mode)

--- a/src/Windows Code Release 3/graphics.cpp
+++ b/src/Windows Code Release 3/graphics.cpp
@@ -13,6 +13,7 @@
 #include "text.h"
 #include "exlsound.h"
 #include "graphutl.h"
+#include "graphutl_helpers.hpp"
 
 extern HWND	mainPtr;
 extern RECT	windRect;
@@ -264,7 +265,7 @@ void plop_fancy_startup()
 	graphic_ul.y = (whole_window.bottom - 350) / 2 - uly - 10;
 	to_rect = from_rect;
 	OffsetRect(&to_rect,graphic_ul.x,graphic_ul.y);
-	rect_draw_some_item(pict_to_draw,from_rect,pict_to_draw,to_rect,0,1);
+	rect_draw_some_item_bmp(pict_to_draw,from_rect,pict_to_draw,to_rect,0,1);
 	play_sound(95);
 	//ulx = sx;
 	//uly = sy;
@@ -292,7 +293,7 @@ void plop_fancy_startup()
 	to_rect = from_rect;
 
 	OffsetRect(&to_rect,-1 * to_rect.left + graphic_ul.x,-1 * to_rect.top + graphic_ul.y);
-	rect_draw_some_item(pict_to_draw,from_rect,pict_to_draw,to_rect,0,1);
+	rect_draw_some_item_bmp(pict_to_draw,from_rect,pict_to_draw,to_rect,0,1);
 	DeleteObject(pict_to_draw);
 
 	play_sound(-22);
@@ -354,14 +355,14 @@ void draw_startup(short but_type)
 	paint_pattern(NULL,1,r4,0);
 	to_rect = startup_from[0];
 	OffsetRect(&to_rect,5,5);
-	rect_draw_some_item(startup_gworld,startup_from[0],startup_gworld,to_rect,0,1);
+	rect_draw_some_item_bmp(startup_gworld,startup_from[0],startup_gworld,to_rect,0,1);
 
 //	to_rect = startup_from[2];
 //	OffsetRect(&to_rect,306,(-1 * to_rect.top) + 356);
-//	rect_draw_some_item(startup_gworld,startup_from[2],startup_gworld,to_rect,0,1);
+//	rect_draw_some_item_bmp(startup_gworld,startup_from[2],startup_gworld,to_rect,0,1);
 
 	for (i = 0; i < 5; i++) {
-		rect_draw_some_item(startup_gworld,startup_from[1],startup_gworld,startup_button[i],0,1);
+		rect_draw_some_item_bmp(startup_gworld,startup_from[1],startup_gworld,startup_button[i],0,1);
 		draw_start_button(i,but_type);
 		}
 	draw_startup_anim();
@@ -416,7 +417,7 @@ void draw_startup_stats()
 				OffsetRect(&from_rect,56 * (i / 3),36 * (i % 3));
 				to_rect = party_from,
 				OffsetRect(&to_rect,pc_rect.left,pc_rect.top + 2);
-				rect_draw_some_item(party_template_gworld,from_rect,
+				rect_draw_some_item_bmp(party_template_gworld,from_rect,
 					party_template_gworld,to_rect,0,1);
 				InflateRect(&to_rect,1,1);
             OffsetRect(&to_rect,ulx,uly);
@@ -481,9 +482,9 @@ void draw_startup_anim()
 	anim_from = anim_to;
 	OffsetRect(&anim_from,-1,-4 + startup_anim_pos);
 	startup_anim_pos = (startup_anim_pos + 1) % 542;
-	rect_draw_some_item(startup_button_orig,anim_size,startup_button_g,anim_size,0,0);
-	rect_draw_some_item(anim_mess,anim_from,startup_button_g,anim_to,1,0);
-	rect_draw_some_item(startup_button_g,anim_size,startup_button_g,startup_button[5],0,1);
+	rect_draw_some_item_bmp(startup_button_orig,anim_size,startup_button_g,anim_size,0,0);
+	rect_draw_some_item_bmp(anim_mess,anim_from,startup_button_g,anim_to,1,0);
+	rect_draw_some_item_bmp(startup_button_g,anim_size,startup_button_g,startup_button[5],0,1);
 }
 
 void draw_start_button(short which_position,short which_button)
@@ -507,7 +508,7 @@ void draw_start_button(short which_position,short which_button)
 	to_rect.right = to_rect.left + 40;
 	to_rect.bottom = to_rect.top + 40;
    from_rect.top += 4; to_rect.top += 4;
-	rect_draw_some_item(startup_gworld,from_rect,startup_gworld,to_rect,0,1);
+   rect_draw_some_item_bmp(startup_gworld,from_rect,startup_gworld,to_rect,0,1);
 
 	//TextFont(dungeon_font_num);
 	//TextFace(0);
@@ -636,7 +637,7 @@ void Set_up_win ()
 	storage_gworld = CreateCompatibleBitmap(main_dc,temp_rect.right,temp_rect.bottom);
 	
 	temp_gworld = load_pict(800,main_dc);
-	rect_draw_some_item(temp_gworld,r,storage_gworld,r,0,0);
+	rect_draw_some_item_bmp(temp_gworld,r,storage_gworld,r,0,0);
 	DeleteObject(temp_gworld);
 	
 	terrain_screen_gworld = load_pict(705,main_dc);
@@ -658,7 +659,7 @@ void Set_up_win ()
 		for (j = 0; j < 2; j++) {
 			pat_to = pat_to_orig;
 			OffsetRect(&pat_to,64 * i, 64 * j);
-			rect_draw_some_item(mixed_gworld,pat_from,status_pattern_gworld,
+			rect_draw_some_item_bmp(mixed_gworld,pat_from,status_pattern_gworld,
 				pat_to,0,0);
 			}
 
@@ -672,14 +673,14 @@ void Set_up_win ()
 		
 	for (i = 0; i < 9; i++) {
 		bg_bitmap[i] = CreateCompatibleBitmap(main_dc,8,8);
-		rect_draw_some_item(mixed_gworld,bg_from[i],bg_bitmap[i],brush_to,0,0);
+		rect_draw_some_item_bmp(mixed_gworld,bg_from[i],bg_bitmap[i],brush_to,0,0);
 		bg[i] = CreatePatternBrush(bg_bitmap[i]);
 		}
 	for (i = 0; i < 25; i++) {
 		map_from = map_from_orig;
 		OffsetRect(&map_from,8 * (i / 10),8 * (i % 10));
 		map_bitmap[i] = CreateCompatibleBitmap(main_dc,8,8);
-		rect_draw_some_item(mixed_gworld,map_from,map_bitmap[i],brush_to,0,0);
+		rect_draw_some_item_bmp(mixed_gworld,map_from,map_bitmap[i],brush_to,0,0);
 		map_brush[i] = CreatePatternBrush(map_bitmap[i]);
 		}
 		/*
@@ -776,17 +777,17 @@ void load_main_screen()
 
 	pc_stats_gworld = CreateCompatibleBitmap(main_dc,271,116);
 	to_rect.right = 271; to_rect.bottom = 116;
-	rect_draw_some_item(temp_gworld,from_rect,pc_stats_gworld,to_rect,0,0);
+	rect_draw_some_item_bmp(temp_gworld,from_rect,pc_stats_gworld,to_rect,0,0);
 	
 	item_stats_gworld = CreateCompatibleBitmap(main_dc,271,144);
 	to_rect.bottom = 144;
 	from_rect.top = 116; from_rect.bottom = 260;
-	rect_draw_some_item(temp_gworld,from_rect,item_stats_gworld,to_rect,0,0);
+	rect_draw_some_item_bmp(temp_gworld,from_rect,item_stats_gworld,to_rect,0,0);
 
 	text_area_gworld = CreateCompatibleBitmap(main_dc,256,138);
 	to_rect.right = 256; to_rect.bottom = 138;
 	from_rect.top = 260; from_rect.bottom = 398; from_rect.right = 256;
-	rect_draw_some_item(temp_gworld,from_rect,text_area_gworld,to_rect,0,0);
+	rect_draw_some_item_bmp(temp_gworld,from_rect,text_area_gworld,to_rect,0,0);
 
 	DeleteObject(temp_gworld);
 
@@ -898,7 +899,7 @@ void draw_main_screen()
 		}
 		else {
 			draw_buttons(0);
-			rect_draw_some_item (terrain_screen_gworld, win_from_rects[0], terrain_screen_gworld, win_to_rects[0], 0, 1);
+			rect_draw_some_item_bmp(terrain_screen_gworld, win_from_rects[0], terrain_screen_gworld, win_to_rects[0], 0, 1);
 
 
 			if ((current_pc < 6) && (overall_mode == 10))
@@ -1046,7 +1047,7 @@ void draw_buttons(short mode)
 		}
 
 	dest_rec = win_to_rects[1];
-	rect_draw_some_item(buttons_gworld,source_rect,buttons_gworld,dest_rec,(spec_draw == TRUE) ? 2 : 0,1);
+	rect_draw_some_item_bmp(buttons_gworld,source_rect,buttons_gworld,dest_rec,(spec_draw == TRUE) ? 2 : 0,1);
 
 	put_background();
 
@@ -1137,7 +1138,7 @@ void put_text_bar(char *str)
 	COLORREF x = RGB(0,0,0),y = RGB(255,255,255);
 	UINT c;
 
-	rect_draw_some_item (orig_text_bar_gworld, win_from_rects[4], text_bar_gworld, win_from_rects[4], 0, 0);
+	rect_draw_some_item_bmp(orig_text_bar_gworld, win_from_rects[4], text_bar_gworld, win_from_rects[4], 0, 0);
 
 	hdc = CreateCompatibleDC(main_dc);
 	SelectPalette(hdc,hpal,0);
@@ -1180,7 +1181,7 @@ void put_text_bar(char *str)
 
 	SelectObject(hdc,store_bmp);
 	DeleteObject(hdc);
-	rect_draw_some_item (text_bar_gworld, win_from_rects[4], text_bar_gworld, win_to_rects[4], 0, 1);
+	rect_draw_some_item_bmp(text_bar_gworld, win_from_rects[4], text_bar_gworld, win_to_rects[4], 0, 1);
 }
 
 // This is called when a new situation is entered. It figures out what graphics are needed,
@@ -1507,11 +1508,11 @@ void update_pc_graphics()
 				source_rect.top = 36 * (adven[i].which_graphic % 8);
 				source_rect.bottom = 36 * (adven[i].which_graphic % 8) + 36;
 				
-				rect_draw_some_item(temp_gworld,source_rect,party_template_gworld,template_rect,0,0);
+				rect_draw_some_item_bmp(temp_gworld,source_rect,party_template_gworld,template_rect,0,0);
 				
 				OffsetRect(&source_rect,280,0);
 				OffsetRect(&template_rect,0,108);
-				rect_draw_some_item(temp_gworld,source_rect,party_template_gworld,template_rect,0,0);
+				rect_draw_some_item_bmp(temp_gworld,source_rect,party_template_gworld,template_rect,0,0);
 			
 				which_graphic_index[i] = adven[i].which_graphic;
 				}
@@ -1545,7 +1546,7 @@ void put_graphics_in_template()
 					from_rect = calc_rect(which_position % 10,which_position / 10);
 					to_rect = calc_rect(i % 10,i / 10);
 				
-					rect_draw_some_item(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
+					rect_draw_some_item_bmp(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
 					storage_status[i] = 1;
 					}
 			DisposeGWorld (temp_gworld);		
@@ -1573,7 +1574,7 @@ void put_graphics_in_template()
 					from_rect = calc_rect((which_position / 10) * 2,which_position % 10);
 					to_rect = calc_rect(i % 10,i / 10);
 				
-					rect_draw_some_item(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
+					rect_draw_some_item_bmp(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
 				
 					storage_status[i] = 1;
 					}
@@ -1584,7 +1585,7 @@ void put_graphics_in_template()
 					from_rect = calc_rect((which_position / 10) * 2 + 1,which_position % 10);
 					to_rect = calc_rect(i % 10,i / 10);
 				
-					rect_draw_some_item(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
+					rect_draw_some_item_bmp(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
 				
 					storage_status[i] = 1;
 					}
@@ -1613,7 +1614,7 @@ void put_graphics_in_template()
 					from_rect = calc_rect((which_position / 10) * 2 + 4,which_position % 10);
 					to_rect = calc_rect(i % 10,i / 10);
 				
-					rect_draw_some_item(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
+					rect_draw_some_item_bmp(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
 				
 					storage_status[i] = 1;
 					}
@@ -1624,7 +1625,7 @@ void put_graphics_in_template()
 					from_rect = calc_rect((which_position / 10) * 2 + 5,which_position % 10);
 					to_rect = calc_rect(i % 10,i / 10);
 				
-					rect_draw_some_item(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
+					rect_draw_some_item_bmp(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
 				
 					storage_status[i] = 1;
 					}
@@ -1649,7 +1650,7 @@ void put_graphics_in_template()
 				from_rect = calc_rect(4 * (which_position / 5) + offset,which_position % 5);
 				to_rect = calc_rect(i % 10,i / 10);
 				
-				rect_draw_some_item(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
+				rect_draw_some_item_bmp(temp_gworld,from_rect,storage_gworld,to_rect,0,0);
 			
 				storage_status[i] = 1;
 				}
@@ -2143,7 +2144,7 @@ void draw_trim(short q,short r,short which_trim,short which_mode)
 	to_rect.top = to_rect.top + trim_rects[which_mode].top;
 	OffsetRect(&to_rect,-61,-37);
 
-	rect_draw_some_item(mixed_gworld,from_rect,terrain_screen_gworld,to_rect,1,0);
+	rect_draw_some_item_bmp(mixed_gworld,from_rect,terrain_screen_gworld,to_rect,1,0);
 }
 
 
@@ -2179,7 +2180,7 @@ void place_road(short q,short r,location where)
 	if ((where.y == 0) || (extend_road_terrain(ter) == TRUE)) {
 		to_rect = road_dest_rects[0];
 		OffsetRect(&to_rect,13 + q * 28,13 + r * 36);
-		rect_draw_some_item (fields_gworld, road_rects[1], terrain_screen_gworld, to_rect, 0, 0);
+		rect_draw_some_item_bmp(fields_gworld, road_rects[1], terrain_screen_gworld, to_rect, 0, 0);
 		}
 
 	if (((is_out()) && (where.x < 96)) || (!(is_out()) && (where.x < town_size[town_type] - 1)))
@@ -2188,7 +2189,7 @@ void place_road(short q,short r,location where)
 	 || (extend_road_terrain(ter) == TRUE)) {
 		to_rect = road_dest_rects[1];
 		OffsetRect(&to_rect,13 + q * 28,13 + r * 36);
-		rect_draw_some_item (fields_gworld, road_rects[0], terrain_screen_gworld, to_rect, 0, 0);
+		rect_draw_some_item_bmp(fields_gworld, road_rects[0], terrain_screen_gworld, to_rect, 0, 0);
 		}
 
 	if (((is_out()) && (where.y < 96)) || (!(is_out()) && (where.y < town_size[town_type] - 1)))
@@ -2197,7 +2198,7 @@ void place_road(short q,short r,location where)
 	 || (extend_road_terrain(ter) == TRUE)) {
 		to_rect = road_dest_rects[2];
 		OffsetRect(&to_rect,13 + q * 28,13 + r * 36);
-		rect_draw_some_item (fields_gworld, road_rects[1], terrain_screen_gworld, to_rect, 0, 0);
+		rect_draw_some_item_bmp(fields_gworld, road_rects[1], terrain_screen_gworld, to_rect, 0, 0);
 		}
 
 	if (where.x > 0)
@@ -2205,7 +2206,7 @@ void place_road(short q,short r,location where)
 	if ((where.x == 0) || (extend_road_terrain(ter) == TRUE)) {
 		to_rect = road_dest_rects[3];
 		OffsetRect(&to_rect,13 + q * 28,13 + r * 36);
-		rect_draw_some_item (fields_gworld, road_rects[0], terrain_screen_gworld, to_rect, 0, 0);
+		rect_draw_some_item_bmp(fields_gworld, road_rects[0], terrain_screen_gworld, to_rect, 0, 0);
 		}
 
 }
@@ -2322,14 +2323,14 @@ void pre_boom_space(location where,short mode,short type,short damage,short soun
 			else OffsetRect(&dest_rect,store_anim_ul.x,store_anim_ul.y);
 
 	OffsetRect(&source_rect,-1 * store_rect.left + 28 * type,-1 * store_rect.top);
-//	rect_draw_some_item(fields_gworld,source_rect,terrain_screen_gworld,dest_rect,1,1);
+//	rect_draw_some_item_bmp(fields_gworld,source_rect,terrain_screen_gworld,dest_rect,1,1);
 //	print_nums(0,source_rect.left,source_rect.top);
 //   print_nums(1,dest_rect.left,dest_rect.top);
 
 	OffsetRect(&terrain_from,x_adj,y_adj);
-	rect_draw_some_item(terrain_screen_gworld,terrain_from,mixed_gworld,mixed_square,0,0);
-	rect_draw_some_item(fields_gworld,source_rect,mixed_gworld,mixed_square,1,0);
-   rect_draw_some_item(mixed_gworld,mixed_square,mixed_gworld,dest_rect,0,1);
+	rect_draw_some_item_bmp(terrain_screen_gworld,terrain_from,mixed_gworld,mixed_square,0,0);
+	rect_draw_some_item_bmp(fields_gworld,source_rect,mixed_gworld,mixed_square,1,0);
+	rect_draw_some_item_bmp(mixed_gworld,mixed_square,mixed_gworld,dest_rect,0,1);
 
 	if ((cartoon_happening == FALSE) && (dest_rect.right - dest_rect.left >= 28)
 		&& (dest_rect.bottom - dest_rect.top >= 36)) {
@@ -2376,8 +2377,8 @@ void draw_pointing_arrows()
 		|| (overall_mode == 35)) 
 			return;
 	for (i = 0; i < 4; i++) {
-		rect_draw_some_item (mixed_gworld,sources[i],mixed_gworld,dests[i * 2],1,1);
-		rect_draw_some_item (mixed_gworld,sources[i],mixed_gworld,dests[i * 2 + 1],1,1);
+		rect_draw_some_item_bmp(mixed_gworld,sources[i],mixed_gworld,dests[i * 2],1,1);
+		rect_draw_some_item_bmp(mixed_gworld,sources[i],mixed_gworld,dests[i * 2 + 1],1,1);
 		}
 }
 
@@ -2394,7 +2395,7 @@ void redraw_terrain()
 				OffsetRect(&to_rect,306,5);
 				else OffsetRect(&to_rect,store_anim_ul.x,store_anim_ul.y);
 			}
-	rect_draw_some_item (terrain_screen_gworld, win_from_rects[0], terrain_screen_gworld, to_rect, 0, 1);
+	rect_draw_some_item_bmp(terrain_screen_gworld, win_from_rects[0], terrain_screen_gworld, to_rect, 0, 1);
 
 
 	// Now place arrows
@@ -2419,7 +2420,7 @@ void draw_targets(location center)
 			dest_rect = coord_to_rect(spell_targets[i].x - center.x + 4,spell_targets[i].y - center.y + 4);
 			OffsetRect(&dest_rect,5,5);
 			InflateRect(&dest_rect,-8,-12);
-			rect_draw_some_item (mixed_gworld,source_rect,mixed_gworld,dest_rect,1,1);
+			rect_draw_some_item_bmp(mixed_gworld,source_rect,mixed_gworld,dest_rect,1,1);
 			}
 }
 
@@ -2560,7 +2561,7 @@ void redraw_partial_terrain(RECT redraw_rect)
 
 	OffsetRect(&redraw_rect,5, 5);
 	
-	rect_draw_some_item(terrain_screen_gworld,from_rect,terrain_screen_gworld,redraw_rect,0,1);
+	rect_draw_some_item_bmp(terrain_screen_gworld,from_rect,terrain_screen_gworld,redraw_rect,0,1);
 
 }
 

--- a/src/Windows Code Release 3/graphutl.cpp
+++ b/src/Windows Code Release 3/graphutl.cpp
@@ -9,8 +9,8 @@
 #include "text.h"
 #include "string.h"
 #include "exlsound.h"
-
 #include "graphutl.h"
+#include "graphutl_helpers.hpp"
 
 extern HWND mainPtr;
 extern HPALETTE hpal,opening_palette;
@@ -666,7 +666,7 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 				for (j = 0; j < 4; j++) {
 					pat_dest = pat_dest_orig;
 					OffsetRect(&pat_dest,64 * i, 64 * j);
-					rect_draw_some_item(mixed_gworld,pattern_source,
+					rect_draw_some_item_bmp(mixed_gworld,pattern_source,
 						dialog_pattern_gworld,pat_dest,0,0);
 					}
 			}
@@ -681,7 +681,7 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 					for (j = 0; j < 4; j++) {
 						pat_dest = pat_dest_orig;
 						OffsetRect(&pat_dest,64 * i, 64 * j);
-						rect_draw_some_item(mixed_gworld,pattern_source,
+						rect_draw_some_item_bmp(mixed_gworld,pattern_source,
 							pattern_gworld,pat_dest,0,0);
 						}
 				}
@@ -702,13 +702,13 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 				OffsetRect(&draw_from, -192 * i, -256 * j);
 				switch (which_mode) {
 					case 0:
-						rect_draw_some_item(source_pat,draw_from,
+						rect_draw_some_item_bmp(source_pat,draw_from,
 							dest,draw_to,0,0); break;
 					case 1:
-						rect_draw_some_item(source_pat,draw_from,
+						rect_draw_some_item_bmp(source_pat,draw_from,
 							source_pat,draw_to,0,1); break;
 					case 2:
-						rect_draw_some_item(source_pat,draw_from,
+						rect_draw_some_item_bmp(source_pat,draw_from,
 							dest,draw_to,0,2); break;
 					}
 				}

--- a/src/Windows Code Release 3/graphutl_helpers.hpp
+++ b/src/Windows Code Release 3/graphutl_helpers.hpp
@@ -28,3 +28,27 @@ static inline void rect_draw_some_item_either(HBITMAP src,RECT src_rect,short wi
 		rect_draw_some_item_dc(src, src_rect, hDC, dest_rect, trans, main_win);
 	}
 }
+
+// which_mode is 0 ... dest is a bitmap
+// is 1 ... ignore dest ... paint on mainPtr
+// is 2 ... dest is a dialog, use the dialog pattern
+// both pattern gworlds are 192 x 256
+static inline void paint_pattern_bmp(HBITMAP dest, RECT dest_rect, short which_pattern)
+{
+	paint_pattern(dest, 0, dest_rect, which_pattern);
+}
+
+static inline void paint_pattern_main(RECT dest_rect, short which_pattern)
+{
+	paint_pattern(nullptr, 1, dest_rect, which_pattern);
+}
+
+static inline void paint_pattern_dc(HDC dest, RECT dest_rect, short which_pattern)
+{
+	paint_pattern(reinterpret_cast<HBITMAP>(dest), 2, dest_rect, which_pattern);
+}
+
+static inline void paint_pattern_wnd(HWND dest, RECT dest_rect, short which_pattern)
+{
+	paint_pattern(reinterpret_cast<HBITMAP>(dest), 1, dest_rect, which_pattern);
+}

--- a/src/Windows Code Release 3/graphutl_helpers.hpp
+++ b/src/Windows Code Release 3/graphutl_helpers.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+// Stopgap mechanism to reduce the amount of casting to known places only for now
+
+static inline void rect_draw_some_item_bmp(HBITMAP src, RECT src_rect, HBITMAP dest, RECT dest_rect, short trans, short main_win)
+{
+	rect_draw_some_item(src, src_rect, dest, dest_rect, trans, main_win);
+}
+
+static inline void rect_draw_some_item_wnd(HBITMAP src,RECT src_rect,HWND dest,RECT dest_rect, short trans, short main_win)
+{
+	rect_draw_some_item(src, src_rect, reinterpret_cast<HBITMAP>(dest), dest_rect, trans, main_win);
+}
+
+static inline void rect_draw_some_item_dc(HBITMAP src,RECT src_rect,HDC dest,RECT dest_rect, short trans, short main_win)
+{
+	rect_draw_some_item(src, src_rect, reinterpret_cast<HBITMAP>(dest), dest_rect, trans, main_win);
+}
+
+static inline void rect_draw_some_item_either(HBITMAP src,RECT src_rect,short win_or_gworld, HWND hWnd, HDC hDC,RECT dest_rect, short trans, short main_win)
+{
+	if(win_or_gworld == 1)
+	{
+		rect_draw_some_item_wnd(src, src_rect, hWnd, dest_rect, trans, main_win);
+	}
+	else
+	{
+		rect_draw_some_item_dc(src, src_rect, hDC, dest_rect, trans, main_win);
+	}
+}

--- a/src/Windows Code Release 3/gutils.cpp
+++ b/src/Windows Code Release 3/gutils.cpp
@@ -13,6 +13,7 @@
 #include "exlsound.h"
 #include "graphutl.h"
 #include "stdio.h"
+#include "graphutl_helpers.hpp"
 
 extern HWND	mainPtr;
 extern RECT	windRect;
@@ -245,8 +246,8 @@ void draw_one_terrain_spot (short i,short j,short terrain_to_draw,short dest)
 			}
 
 	if (dest == 0)
-		rect_draw_some_item(source_gworld, source_rect, terrain_screen_gworld, where_draw, (unsigned char) 0, 0);
-		else rect_draw_some_item(source_gworld, source_rect, terrain_screen_gworld, where_draw, (unsigned char) 0, 1);
+		rect_draw_some_item_bmp(source_gworld, source_rect, terrain_screen_gworld, where_draw, (unsigned char) 0, 0);
+		else rect_draw_some_item_bmp(source_gworld, source_rect, terrain_screen_gworld, where_draw, (unsigned char) 0, 1);
 }
 
 void draw_monsters()
@@ -289,28 +290,28 @@ void draw_monsters()
 								source_rect = get_custom_rect(picture_wanted % 1000 +
 								  ((party.out_c[i].direction < 4) ? 0 : (width * height)) + k);
 								to_rect = monst_rects[(width - 1) * 2 + height - 1][k];
-								rect_draw_some_item(spec_scen_g, source_rect, small_temp_gworld,to_rect, 0, 0); 			
+								rect_draw_some_item_bmp(spec_scen_g, source_rect, small_temp_gworld,to_rect, 0, 0);
 								source_rect = to_rect;
 								OffsetRect(&to_rect,13 + 28 * where_draw.x,13 + 36 * where_draw.y);
-								rect_draw_some_item(small_temp_gworld, source_rect, terrain_screen_gworld,to_rect, 1, 0);
+								rect_draw_some_item_bmp(small_temp_gworld, source_rect, terrain_screen_gworld,to_rect, 1, 0);
 								}
 							//source_rect = to_rect = monst_rects[0][0];
 							//OffsetRect(&to_rect,13 + 28 * where_draw.x,13 + 36 * where_draw.y);
-							//rect_draw_some_item(small_temp_gworld, source_rect, terrain_screen_gworld,to_rect, 1, 0);
+							//rect_draw_some_item_bmp(small_temp_gworld, source_rect, terrain_screen_gworld,to_rect, 1, 0);
 							}
 						if (picture_wanted < 1000) {
 							for (k = 0; k < width * height; k++) {
 								source_rect = get_monster_template_rect(party.out_c[i].what_monst.monst[j],
 								  (party.out_c[i].direction < 4) ? 0 : 1,k);
 								to_rect = monst_rects[(width - 1) * 2 + height - 1][k];
-								rect_draw_some_item(storage_gworld, source_rect, small_temp_gworld,to_rect, 0, 0); 			
+								rect_draw_some_item_bmp(storage_gworld, source_rect, small_temp_gworld,to_rect, 0, 0);
 								source_rect = to_rect;
 								OffsetRect(&to_rect,13 + 28 * where_draw.x,13 + 36 * where_draw.y);
-								rect_draw_some_item(small_temp_gworld, source_rect, terrain_screen_gworld,to_rect, 1, 0);
+								rect_draw_some_item_bmp(small_temp_gworld, source_rect, terrain_screen_gworld,to_rect, 1, 0);
 								}
 							//source_rect = to_rect = monst_rects[0][0];
 							//OffsetRect(&to_rect,13 + 28 * where_draw.x,13 + 36 * where_draw.y);
-							//rect_draw_some_item(small_temp_gworld, source_rect, terrain_screen_gworld,to_rect, 1, 0);
+							//rect_draw_some_item_bmp(small_temp_gworld, source_rect, terrain_screen_gworld,to_rect, 1, 0);
 							}
 					}
 				}
@@ -475,7 +476,7 @@ void draw_items()
 						dest_rect = coord_to_rect(where_draw.x,where_draw.y);
 						terrain_there[where_draw.x][where_draw.y] = -1;
 
-						rect_draw_some_item(spec_scen_g,
+						rect_draw_some_item_bmp(spec_scen_g,
 						 source_rect, terrain_screen_gworld, dest_rect, 1, 0); 
 						}
 						else {
@@ -488,7 +489,7 @@ void draw_items()
 								dest_rect.left += 5;
 								dest_rect.right -= 5;
 								}
-							rect_draw_some_item((t_i.items[i].graphic_num < 45) ? items_gworld : tiny_obj_gworld,
+							rect_draw_some_item_bmp((t_i.items[i].graphic_num < 45) ? items_gworld : tiny_obj_gworld,
 							 source_rect, terrain_screen_gworld, dest_rect, 1, 0); 
 					 		}
 					}

--- a/src/Windows Code Release 3/items.cpp
+++ b/src/Windows Code Release 3/items.cpp
@@ -10,7 +10,6 @@
 #include "fields.h"
 #include "locutils.h"
 #include "newgraph.h"
-#include "dlogtool.h"
 #include "itemdata.h"
 #include "infodlgs.h"
 #include "exlsound.h"

--- a/src/Windows Code Release 3/newgraph.cpp
+++ b/src/Windows Code Release 3/newgraph.cpp
@@ -856,9 +856,9 @@ char *cost_strs[] = {"Extremely Cheap","Very Reasonable","Pretty Average","Somew
 	InflateRect(&area_rect,-1,-1);
 	SelectObject(hdc,store_bmp);
 	if (draw_mode > 0) {
-		paint_pattern(talk_gworld,0,clip_area_rect,3);
+		paint_pattern_bmp(talk_gworld,clip_area_rect,3);
 		}
-		else paint_pattern(talk_gworld,0,area_rect,3);
+		else paint_pattern_bmp(talk_gworld,area_rect,3);
 
 	SelectObject(hdc,talk_gworld);
 	//old_brush = SelectObject(hdc,bg[1]);
@@ -1198,9 +1198,9 @@ void place_talk_str(char *str_to_place,char *str_to_place2,short color,RECT c_re
 	//SelectObject(hdc,old_brush);
 	SelectObject(hdc,store_bmp);
 	if (c_rect.right > 0) {
-		paint_pattern(talk_gworld,0,c_rect,3);
+		paint_pattern_bmp(talk_gworld,c_rect,3);
 		}
-		else paint_pattern(talk_gworld,0,area_rect,3);
+		else paint_pattern_bmp(talk_gworld,area_rect,3);
 
 	// Put help button
 	talk_help_rect.right = talk_help_rect.left + help_from.right - help_from.left;

--- a/src/Windows Code Release 3/newgraph.cpp
+++ b/src/Windows Code Release 3/newgraph.cpp
@@ -871,7 +871,7 @@ char *cost_strs[] = {"Extremely Cheap","Very Reasonable","Pretty Average","Somew
 	// Place store icon
 	if (draw_mode == 0) {
 		i = faces[store_shop_type];
-		draw_dialog_graphic((HWND) talk_gworld, face_rect, 1000 + i, FALSE,1);
+		draw_dialog_graphic_bmp(talk_gworld, face_rect, 1000 + i, FALSE);
 		}
 	SelectObject(hdc,talk_gworld);
 
@@ -927,38 +927,38 @@ char *cost_strs[] = {"Extremely Cheap","Very Reasonable","Pretty Average","Somew
 			case 0: case 1: case 2: case 3: case 4:
 				base_item = get_stored_item(what_chosen);
 				base_item.item_properties = base_item.item_properties | 1;
-				draw_dialog_graphic((HWND) talk_gworld, shopping_rects[i][2],1800 + base_item.graphic_num, FALSE,1);
+				draw_dialog_graphic_bmp(talk_gworld, shopping_rects[i][2],1800 + base_item.graphic_num, FALSE);
 				strcpy(cur_name,base_item.full_name);
 				get_item_interesting_string(base_item,cur_info_str);
 				break;
 			case 5:
 				base_item = store_alchemy(what_chosen - 500);
-				draw_dialog_graphic((HWND) talk_gworld, shopping_rects[i][2],1853, FALSE,1);//// all graphic nums
+				draw_dialog_graphic_bmp(talk_gworld, shopping_rects[i][2],1853, FALSE);//// all graphic nums
 				strcpy(cur_name,base_item.full_name);
 				sprintf(cur_info_str,"");
 				break;
 			case 6:
 				//base_item = food_types[what_chosen - 600];
-				//draw_dialog_graphic( talk_gworld, shopping_rects[i][2],633, FALSE,1);
+				//draw_dialog_graphic_bmp(talk_gworld, shopping_rects[i][2],633, FALSE);
 				//strcpy(cur_name,base_item.full_name);
 				//get_item_interesting_string(base_item,cur_info_str);
 				break;
 			case 7:
 				what_chosen -= 700;
-				draw_dialog_graphic(talk_gworld, shopping_rects[i][2],1879, FALSE,1);
+				draw_dialog_graphic_bmp(talk_gworld, shopping_rects[i][2],1879, FALSE);
 				strcpy(cur_name,heal_types[what_chosen]);
 				sprintf(cur_info_str,"");
 				break;
 			case 8:
 				base_item = store_mage_spells(what_chosen - 800 - 30);
-				draw_dialog_graphic(talk_gworld, shopping_rects[i][2],1800 + base_item.graphic_num, FALSE,1);
+				draw_dialog_graphic_bmp(talk_gworld, shopping_rects[i][2],1800 + base_item.graphic_num, FALSE);
 
 				strcpy(cur_name,base_item.full_name);
 				sprintf(cur_info_str,"");
 				break;
 			case 9:
 				base_item = store_priest_spells(what_chosen - 900 - 30);
-				draw_dialog_graphic(talk_gworld, shopping_rects[i][2],1853, FALSE,1);
+				draw_dialog_graphic_bmp(talk_gworld, shopping_rects[i][2],1853, FALSE);
 				strcpy(cur_name,base_item.full_name);
 				sprintf(cur_info_str,"");
 				break;
@@ -967,7 +967,7 @@ char *cost_strs[] = {"Extremely Cheap","Very Reasonable","Pretty Average","Somew
 				what_magic_shop_item = what_chosen % 1000;
 				base_item = party.magic_store_items[what_magic_shop][what_magic_shop_item];
 				base_item.item_properties = base_item.item_properties | 1;
-				draw_dialog_graphic(talk_gworld, shopping_rects[i][2],1800 + base_item.graphic_num, FALSE,1);
+				draw_dialog_graphic_bmp(talk_gworld, shopping_rects[i][2],1800 + base_item.graphic_num, FALSE);
 				strcpy(cur_name,base_item.full_name);
 				get_item_interesting_string(base_item,cur_info_str);
 				break;
@@ -1211,14 +1211,14 @@ void place_talk_str(char *str_to_place,char *str_to_place2,short color,RECT c_re
 		if (store_talk_face_pic >= 0)
 			face_to_draw = store_talk_face_pic;
 		if (store_talk_face_pic >= 1000) {
-			draw_dialog_graphic((HWND)  talk_gworld, face_rect, 2400 + store_talk_face_pic - 1000, FALSE,1);
+			draw_dialog_graphic_bmp(talk_gworld, face_rect, 2400 + store_talk_face_pic - 1000, FALSE);
 			}
 			else {
 				i = get_monst_picnum(store_monst_type);
 
 				if (face_to_draw <= 0)
-					draw_dialog_graphic((HWND)  talk_gworld, face_rect, 400 + i, FALSE,1);
-					else draw_dialog_graphic((HWND)  talk_gworld, face_rect, 1000 + face_to_draw, FALSE,1);
+					draw_dialog_graphic_bmp(talk_gworld, face_rect, 400 + i, FALSE);
+					else draw_dialog_graphic_bmp(talk_gworld, face_rect, 1000 + face_to_draw, FALSE);
 				}
 		}
 	SelectObject(hdc,talk_gworld);

--- a/src/Windows Code Release 3/newgraph.cpp
+++ b/src/Windows Code Release 3/newgraph.cpp
@@ -7,6 +7,7 @@
 #include "gutils.h"
 #include "monster.h"
 #include "dlogtool.h"
+#include "dlogtool_helpers.hpp"
 #include "newgraph.h"
 #include "fileio.h"
 #include "itemdata.h"
@@ -15,6 +16,7 @@
 #include "text.h"
 #include "exlsound.h"
 #include "graphutl.h"
+#include "graphutl_helpers.hpp"
 
 short far monsters_faces[190] = {0,1,2,3,4,5,6,7,8,9,
 							10,0,12,11,11,12,13,13,2,11,
@@ -301,7 +303,7 @@ void apply_light_mask()
 				}
 			}
 
-	//rect_draw_some_item(light_mask_gworld,big_from,terrain_screen_gworld,big_to,0,0);
+	//rect_draw_some_item_bmp(light_mask_gworld,big_from,terrain_screen_gworld,big_to,0,0);
 	PaintRgn(hdc,dark_mask_region);
 	SelectObject(hdc,store_bmp);
 	DeleteObject(hdc);
@@ -473,7 +475,7 @@ void do_missile_anim(short num_steps,location missile_origin,short sound_num)
 	draw_terrain(1);
 	to_rect = ter_scrn_rect;
 	OffsetRect(&to_rect,current_terrain_ul.x, current_terrain_ul.y);
-	rect_draw_some_item(terrain_screen_gworld,ter_scrn_rect,
+	rect_draw_some_item_bmp(terrain_screen_gworld,ter_scrn_rect,
 		terrain_screen_gworld,to_rect,0,1);
 							
 	// create and clip temporary anim template 
@@ -538,13 +540,13 @@ void do_missile_anim(short num_steps,location missile_origin,short sound_num)
 				SectRect(&temp_rect,&active_area_rect,&missile_place_rect[i]);
 
 				// Now put terrain in temporary;
-				rect_draw_some_item(terrain_screen_gworld,missile_place_rect[i],
+				rect_draw_some_item_bmp(terrain_screen_gworld,missile_place_rect[i],
 					temp_gworld,missile_place_rect[i],0,0);
 				// Now put in missile
 				from_rect = missile_origin_rect[i];
 				if (store_missiles[i].missile_type >= 7)
 					OffsetRect(&from_rect,18 * (t % 8),0);
-				rect_draw_some_item(missiles_gworld,from_rect,
+				rect_draw_some_item_bmp(missiles_gworld,from_rect,
 					temp_gworld,temp_rect,1,0);
 				}
 
@@ -553,13 +555,13 @@ void do_missile_anim(short num_steps,location missile_origin,short sound_num)
 			if (store_missiles[i].missile_type >= 0) {
 				to_rect = store_erase_rect[i];
 				OffsetRect(&to_rect,current_terrain_ul.x,current_terrain_ul.y);
-				rect_draw_some_item(terrain_screen_gworld,store_erase_rect[i],
+				rect_draw_some_item_bmp(terrain_screen_gworld,store_erase_rect[i],
 					terrain_screen_gworld,to_rect,0,1);
 
 				to_rect = missile_place_rect[i];
 				store_erase_rect[i] = to_rect;
 				OffsetRect(&to_rect,current_terrain_ul.x,current_terrain_ul.y);
-				rect_draw_some_item(temp_gworld,missile_place_rect[i],
+				rect_draw_some_item_bmp(temp_gworld,missile_place_rect[i],
 					temp_gworld,to_rect,0,1);
 				}
 		if ((PSD[306][6] == 3) || ((PSD[306][6] == 1) && (t % 4 == 0)) || ((PSD[306][6] == 2) && (t % 3 == 0)))
@@ -575,7 +577,7 @@ void do_missile_anim(short num_steps,location missile_origin,short sound_num)
 
 	to_rect = ter_scrn_rect;
 	OffsetRect(&to_rect,current_terrain_ul.x,current_terrain_ul.y);
-	rect_draw_some_item(terrain_screen_gworld,ter_scrn_rect,
+	rect_draw_some_item_bmp(terrain_screen_gworld,ter_scrn_rect,
 		terrain_screen_gworld,to_rect,0,1);
 
 		while (t2 - t1 < pause_len + 40) {
@@ -673,7 +675,7 @@ void do_explosion_anim(short sound_num,short special_draw)
 	if (special_draw != 2) {
 		to_rect = ter_scrn_rect;
 		OffsetRect(&to_rect,current_terrain_ul.x, current_terrain_ul.y);
-		rect_draw_some_item(terrain_screen_gworld,ter_scrn_rect,
+		rect_draw_some_item_bmp(terrain_screen_gworld,ter_scrn_rect,
 			terrain_screen_gworld,to_rect,0,1);
 		}
 		
@@ -724,7 +726,7 @@ void do_explosion_anim(short sound_num,short special_draw)
 		// First, lay terrain in temporary graphic area;
 		for (i = 0; i < 30; i++) 
 			if (store_booms[i].boom_type >= 0) 
-				rect_draw_some_item(terrain_screen_gworld,explode_place_rect[i],
+				rect_draw_some_item_bmp(terrain_screen_gworld,explode_place_rect[i],
 					temp_gworld,explode_place_rect[i],0,0);
 
 		// Now put in explosions
@@ -733,7 +735,7 @@ void do_explosion_anim(short sound_num,short special_draw)
 				if ((t + store_booms[i].offset >= 0) && (t + store_booms[i].offset <= 7)) {
 						from_rect = base_rect;
 						OffsetRect(&from_rect,28 * (t + store_booms[i].offset),144 + 36 * (store_booms[i].boom_type));
-						rect_draw_some_item(fields_gworld,from_rect,
+						rect_draw_some_item_bmp(fields_gworld,from_rect,
 							temp_gworld,explode_place_rect[i],1,0);
 					
 					if (store_booms[i].val_to_place > 0) {
@@ -754,7 +756,7 @@ void do_explosion_anim(short sound_num,short special_draw)
 			if (store_booms[i].boom_type >= 0) {
 				to_rect = explode_place_rect[i];
 				OffsetRect(&to_rect,current_terrain_ul.x,current_terrain_ul.y);
-				rect_draw_some_item(temp_gworld,explode_place_rect[i],
+				rect_draw_some_item_bmp(temp_gworld,explode_place_rect[i],
 					temp_gworld,to_rect,0,1);
 				}
 					//if (((PSD[306][6] == 1) && (t % 3 == 0)) || ((PSD[306][6] == 2) && (t % 2 == 0)))
@@ -779,7 +781,7 @@ void do_explosion_anim(short sound_num,short special_draw)
 		}
 	//to_rect = terrain_screen_gworld->portRect;
 	//OffsetRect(&to_rect,current_terrain_ul.h,current_terrain_ul.v);
-	//rect_draw_some_item(terrain_screen_gworld,terrain_screen_gworld->portRect,
+	//rect_draw_some_item_bmp(terrain_screen_gworld,terrain_screen_gworld->portRect,
 	//	terrain_screen_gworld,to_rect,0,1);
 }
 
@@ -904,10 +906,10 @@ char *cost_strs[] = {"Extremely Cheap","Very Reasonable","Pretty Average","Somew
 	SelectObject(hdc,store_bmp);
 	talk_help_rect.right = talk_help_rect.left + help_from.right - help_from.left;
 	talk_help_rect.bottom = talk_help_rect.top + help_from.bottom - help_from.top;
-	rect_draw_some_item(dlg_buttons_gworld,help_from,talk_gworld,talk_help_rect,0,0);
+	rect_draw_some_item_bmp(dlg_buttons_gworld,help_from,talk_gworld,talk_help_rect,0,0);
 	//talk_help_rect.right = talk_help_rect.left + help_from.right - help_from.left;
 	//talk_help_rect.bottom = talk_help_rect.top + help_from.bottom - help_from.top;
-	rect_draw_some_item(dlg_buttons_gworld,done_from,talk_gworld,shop_done_rect,0,0);
+	rect_draw_some_item_bmp(dlg_buttons_gworld,done_from,talk_gworld,shop_done_rect,0,0);
 	SelectObject(hdc,talk_gworld);
 	if (draw_mode == 0)
 		SetTextColor(hdc,PALETTEINDEX(c[0]));
@@ -978,7 +980,7 @@ char *cost_strs[] = {"Extremely Cheap","Very Reasonable","Pretty Average","Somew
 		shopping_rects[i][6].bottom = shopping_rects[i][6].top +
 			(from_rect.bottom - from_rect.top);
 		if ((store_shop_type != 3) && (store_shop_type != 4))
-			rect_draw_some_item(mixed_gworld,item_info_from,talk_gworld,shopping_rects[i][6],1,0);
+			rect_draw_some_item_bmp(mixed_gworld,item_info_from,talk_gworld,shopping_rects[i][6],1,0);
 		SelectObject(hdc,talk_gworld);
 		// Now draw item shopping_rects[i][7]
 		// 0 - whole area, 1 - active area 2 - graphic 3 - item name
@@ -1018,7 +1020,7 @@ void refresh_shopping()
 	for (i = 0; i < 4; i++) {
 		to_rect = from_rects[i];
 		OffsetRect(&to_rect,5,5);
-		rect_draw_some_item(talk_gworld,from_rects[i],talk_gworld,to_rect,0,1);
+		rect_draw_some_item_bmp(talk_gworld,from_rects[i],talk_gworld,to_rect,0,1);
 		}
 }
 
@@ -1203,7 +1205,7 @@ void place_talk_str(char *str_to_place,char *str_to_place2,short color,RECT c_re
 	// Put help button
 	talk_help_rect.right = talk_help_rect.left + help_from.right - help_from.left;
 	talk_help_rect.bottom = talk_help_rect.top + help_from.bottom - help_from.top;
-	rect_draw_some_item(dlg_buttons_gworld,help_from,talk_gworld,talk_help_rect,0,0);
+	rect_draw_some_item_bmp(dlg_buttons_gworld,help_from,talk_gworld,talk_help_rect,0,0);
 
 	// Place face of talkee
 	if ((color == 0) && (c_rect.right == 0)) {
@@ -1451,7 +1453,7 @@ void place_talk_str(char *str_to_place,char *str_to_place2,short color,RECT c_re
 void refresh_talking()
 {
 	RECT from = {0,0,279,415};
-	rect_draw_some_item(talk_gworld,from,talk_gworld,talk_area_rect,0,1);
+	rect_draw_some_item_bmp(talk_gworld,from,talk_gworld,talk_area_rect,0,1);
 }
 
 short scan_for_response(char *str)

--- a/src/Windows Code Release 3/text.cpp
+++ b/src/Windows Code Release 3/text.cpp
@@ -11,7 +11,7 @@
 #include "fields.h"
 #include "exlsound.h"
 #include "graphutl.h"
-	
+#include "graphutl_helpers.hpp"
 
 char far *m_mage_sp[] = {"Spark","Minor Haste","Strength","Flame Cloud","Flame",
 						"Minor Poison","Slow","Dumbfound","Stinking Cloud","Summon Beast",
@@ -153,7 +153,7 @@ void put_pc_screen()
 				right_buttons_same = FALSE;
 
 	// First refresh gworld with the pc info
-	//rect_draw_some_item (orig_pc_info_screen_gworld, erase_rect, pc_info_screen_gworld, erase_rect, 0, 0);
+	//rect_draw_some_item_bmp(orig_pc_info_screen_gworld, erase_rect, pc_info_screen_gworld, erase_rect, 0, 0);
 	// First clean up gworld with pretty patterns
 	// Will rewrite later
 	//FillCRECT(&erase_rect,bg[6]);
@@ -162,21 +162,21 @@ void put_pc_screen()
 	//	erase_rect.right -= 15;
 	from_rect = erase_rect;
 	OffsetRect(&from_rect,-1 * from_rect.left,-1 * from_rect.top);
-	rect_draw_some_item(status_pattern_gworld,from_rect,
+	rect_draw_some_item_bmp(status_pattern_gworld,from_rect,
 		pc_stats_gworld,erase_rect,0,0);
 	//if (right_buttons_same == FALSE) {
 		erase_rect.left = erase_rect.right;
 		erase_rect.right += 13;
 		from_rect = erase_rect;
 		OffsetRect(&from_rect,-1 * from_rect.left,-1 * from_rect.top);
-		rect_draw_some_item(status_pattern_gworld,from_rect,
+		rect_draw_some_item_bmp(status_pattern_gworld,from_rect,
 			pc_stats_gworld,erase_rect,0,0);
 	//	}
 	for (i = 0; i < 3; i++) {
 		//	FillCRECT(&small_erase_rects[i],bg[7]);
 		from_rect = small_erase_rects[i];
 		OffsetRect(&from_rect,-1 * from_rect.left + 208,-1 * from_rect.top + 136);
-		rect_draw_some_item(mixed_gworld,from_rect,
+		rect_draw_some_item_bmp(mixed_gworld,from_rect,
 			pc_stats_gworld,small_erase_rects[i],0,0);
 		}
 
@@ -272,8 +272,8 @@ void put_pc_screen()
 				 to_draw,0,10);
 
 			// Now put trade and info buttons
-			//rect_draw_some_item(mixed_gworld,info_from,pc_stats_gworld,pc_buttons[i][3],1,0);
-			//rect_draw_some_item(mixed_gworld,switch_from,pc_stats_gworld,pc_buttons[i][4],1,0);
+			//rect_draw_some_item_bmp(mixed_gworld,info_from,pc_stats_gworld,pc_buttons[i][3],1,0);
+			//rect_draw_some_item_bmp(mixed_gworld,switch_from,pc_stats_gworld,pc_buttons[i][4],1,0);
 			// do faster!
 			to_draw_rect = pc_buttons[i][3];
 			to_draw_rect.right = pc_buttons[i][4].right + 1;
@@ -282,7 +282,7 @@ void put_pc_screen()
 
 				pc_button_state[i] = 1;
 				SelectObject(hdc,store_bmp);
-				rect_draw_some_item(mixed_gworld,from_rect,pc_stats_gworld,to_draw_rect,1,0);
+				rect_draw_some_item_bmp(mixed_gworld,from_rect,pc_stats_gworld,to_draw_rect,1,0);
 				SelectObject(hdc,pc_stats_gworld);
 				
 			}
@@ -299,7 +299,7 @@ void put_pc_screen()
 
 	// Now put text on window.
 	OffsetRect(&final_to_draw_rect,PC_WIN_UL_X,PC_WIN_UL_Y);
-	rect_draw_some_item (pc_stats_gworld, final_from_draw_rect, pc_stats_gworld, final_to_draw_rect, 0, 1);
+	rect_draw_some_item_bmp(pc_stats_gworld, final_from_draw_rect, pc_stats_gworld, final_to_draw_rect, 0, 1);
 
 	// Sometimes this gets called when character is slain. when that happens, if items for
 	// that PC are up, switch item page.
@@ -336,13 +336,13 @@ void put_item_screen(short screen_num,short suppress_buttons)
 	HBITMAP store_bmp;
 
 	// First refresh gworld with the pc info
-	//rect_draw_some_item (orig_pc_info_screen_gworld, erase_rect, pc_info_screen_gworld, erase_rect, 0, 0);
+	//rect_draw_some_item_bmp(orig_pc_info_screen_gworld, erase_rect, pc_info_screen_gworld, erase_rect, 0, 0);
 	// First clean up gworld with pretty patterns
 	// Will rewrite later
 	//FillCRECT(&erase_rect,bg[6]);
 	from_rect = erase_rect;
 	OffsetRect(&from_rect,-1 * from_rect.left,-1 * from_rect.top);
-	rect_draw_some_item(status_pattern_gworld,from_rect,
+	rect_draw_some_item_bmp(status_pattern_gworld,from_rect,
 		item_stats_gworld,erase_rect,0,0);
 	if (suppress_buttons == 0)
 		for (i = 0; i < 6; i++)
@@ -351,7 +351,7 @@ void put_item_screen(short screen_num,short suppress_buttons)
 			//FillCRECT(&item_screen_button_rects[i],bg[7]);
 			from_rect = item_screen_button_rects[i];
 			OffsetRect(&from_rect,-1 * from_rect.left + 208,-1 * from_rect.top + 136);
-			rect_draw_some_item(mixed_gworld,from_rect,
+			rect_draw_some_item_bmp(mixed_gworld,from_rect,
 				item_stats_gworld,item_screen_button_rects[i],0,0);
 			}
 	//FillCRECT(&upper_frame_rect,bg[7]);
@@ -359,12 +359,12 @@ void put_item_screen(short screen_num,short suppress_buttons)
 	to_rect.right = to_rect.left + 96;
 	from_rect = to_rect;
 	OffsetRect(&from_rect,-1 * from_rect.left + 208,-1 * from_rect.top + 136);
-	rect_draw_some_item(mixed_gworld,from_rect,
+	rect_draw_some_item_bmp(mixed_gworld,from_rect,
 		item_stats_gworld,to_rect,0,0);
 	OffsetRect(&to_rect,96,0);
 	from_rect = to_rect;
 	OffsetRect(&from_rect,-1 * from_rect.left + 208,-1 * from_rect.top + 136);
-	rect_draw_some_item(mixed_gworld,from_rect,
+	rect_draw_some_item_bmp(mixed_gworld,from_rect,
 		item_stats_gworld,to_rect,0,0);
 
 
@@ -512,7 +512,7 @@ void put_item_screen(short screen_num,short suppress_buttons)
 	for (i = 0; i < 3; i++) {
 		dest_rect = parts_of_area_to_draw[i];
 		OffsetRect(&dest_rect,ITEM_WIN_UL_X,ITEM_WIN_UL_Y);
-		rect_draw_some_item (item_stats_gworld, parts_of_area_to_draw[i],
+		rect_draw_some_item_bmp(item_stats_gworld, parts_of_area_to_draw[i],
 		  item_stats_gworld, dest_rect, 0, 1);
 		}
 }
@@ -585,7 +585,7 @@ void place_buy_button(short position,short pc_num,short item_num,HDC hdc)
 		store_selling_values[position] = val_to_place;
 		dest_rect = item_buttons[position][5];
 		dest_rect.right = dest_rect.left + 30;
-		rect_draw_some_item (mixed_gworld, source_rect,
+		rect_draw_some_item_bmp(mixed_gworld, source_rect,
 		  item_stats_gworld, dest_rect, 1, 0);
 		sprintf((char *) store_string,"        %d",val_to_place);
 		//if (val_to_place >= 10000)
@@ -616,18 +616,18 @@ void place_item_button(short which_button_to_put,short which_slot,short which_bu
 		InsetRect(&from_rect,2,2);
 		if (extra_val >= 150) {
 			from_rect = get_custom_rect(extra_val - 150);
-			rect_draw_some_item (spec_scen_g, from_rect,
+			rect_draw_some_item_bmp(spec_scen_g, from_rect,
 			  item_stats_gworld, to_rect, 0, 0);
 			}
 			else {
-				rect_draw_some_item (tiny_obj_gworld, from_rect,
+			rect_draw_some_item_bmp(tiny_obj_gworld, from_rect,
 			  item_stats_gworld, to_rect, 1, 0);
 				}
 		 return;
 		}
 	if (which_button_to_put < 4) { // this means put a regular item button
 		item_area_button_active[which_slot][which_button_position] = TRUE;
-		rect_draw_some_item (mixed_gworld, item_buttons_from[which_button_to_put],
+		rect_draw_some_item_bmp(mixed_gworld, item_buttons_from[which_button_to_put],
 		  item_stats_gworld, item_buttons[which_slot][which_button_position], 1, 0);
 		}
 	if (which_button_to_put == 10) { // this means put all 4
@@ -638,7 +638,7 @@ void place_item_button(short which_button_to_put,short which_slot,short which_bu
 		from_rect = item_buttons_from[0]; from_rect.right = item_buttons_from[3].right;
 		to_rect = item_buttons[which_slot][1];
 		to_rect.right = to_rect.left + from_rect.right - from_rect.left;
-		rect_draw_some_item (mixed_gworld, from_rect,
+		rect_draw_some_item_bmp(mixed_gworld, from_rect,
 		  item_stats_gworld, to_rect, 1, 0);
 		}
 	if (which_button_to_put == 11) { // this means put right 3
@@ -648,7 +648,7 @@ void place_item_button(short which_button_to_put,short which_slot,short which_bu
 		from_rect = item_buttons_from[1]; from_rect.right = item_buttons_from[3].right;
 		to_rect = item_buttons[which_slot][2];
 		to_rect.right = to_rect.left + from_rect.right - from_rect.left;
-		rect_draw_some_item (mixed_gworld, from_rect,
+		rect_draw_some_item_bmp(mixed_gworld, from_rect,
 		  item_stats_gworld, to_rect, 1, 0);
 		}
 }
@@ -672,10 +672,10 @@ void place_item_bottom_buttons()
 			to_rect = item_screen_button_rects[i];
 			//if (current_item_button[i] != adven[i].which_graphic) {
 				current_item_button[i] = adven[i].which_graphic;
-				rect_draw_some_item (mixed_gworld, but_from_rect, item_stats_gworld, to_rect, 0, 0);
+				rect_draw_some_item_bmp(mixed_gworld, but_from_rect, item_stats_gworld, to_rect, 0, 0);
 				pc_from_rect = get_party_template_rect(i,0);
 				InsetRect(&to_rect,2,2);
-				rect_draw_some_item (party_template_gworld, pc_from_rect, item_stats_gworld, to_rect, 0, 0);
+				rect_draw_some_item_bmp(party_template_gworld, pc_from_rect, item_stats_gworld, to_rect, 0, 0);
 			//	}
 
 			}
@@ -749,16 +749,16 @@ void refresh_stat_areas(short mode)
 	x = mode * 10;
 	dest_rect = pc_stats_from;
 	OffsetRect(&dest_rect,PC_WIN_UL_X,PC_WIN_UL_Y);
-	rect_draw_some_item (pc_stats_gworld, pc_stats_from, pc_stats_gworld, dest_rect, x, 1);
+	rect_draw_some_item_bmp(pc_stats_gworld, pc_stats_from, pc_stats_gworld, dest_rect, x, 1);
 	for (i = 0; i < 3; i++) {
 		dest_rect = parts_of_area_to_draw[i];
 		OffsetRect(&dest_rect,ITEM_WIN_UL_X,ITEM_WIN_UL_Y);
-		rect_draw_some_item (item_stats_gworld, parts_of_area_to_draw[i], 
+		rect_draw_some_item_bmp(item_stats_gworld, parts_of_area_to_draw[i],
 		  item_stats_gworld, dest_rect, x, 1);
 		}
 	dest_rect = text_area_from;
 	OffsetRect(&dest_rect,TEXT_WIN_UL_X,TEXT_WIN_UL_Y);
-	rect_draw_some_item (text_area_gworld, text_area_from, text_area_gworld, dest_rect, x, 1);
+	rect_draw_some_item_bmp(text_area_gworld, text_area_from, text_area_gworld, dest_rect, x, 1);
 
 }
 
@@ -839,82 +839,82 @@ void draw_pc_effects(short pc,HDC dest_dc)
 		return;
 			
 	if ((adven[pc].status[0] > 0) && (dest_rect.right < right_limit)) { 
-		rect_draw_some_item (mixed_gworld,source_rects[4],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[4],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[1] > 0) { 
-		rect_draw_some_item (mixed_gworld,source_rects[2],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[2],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[1] < 0) { 
-		rect_draw_some_item (mixed_gworld,source_rects[3],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[3],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[2] > 0) { 
-		rect_draw_some_item (mixed_gworld,source_rects[(adven[pc].status[2] > 4) ? 1 : 0],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[(adven[pc].status[2] > 4) ? 1 : 0],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[4] > 0) { 
-		rect_draw_some_item (mixed_gworld,source_rects[5],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[5],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[3] > 0) { 
-		rect_draw_some_item (mixed_gworld,source_rects[6],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[6],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[3] < 0) { 
-		rect_draw_some_item (mixed_gworld,source_rects[8],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[8],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adven[pc].status[5] > 0) && (dest_rect.right < right_limit)) { 
-		rect_draw_some_item (mixed_gworld,source_rects[9],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[9],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adven[pc].status[6] > 0) && (dest_rect.right < right_limit)) { 
-		rect_draw_some_item (mixed_gworld,source_rects[10],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[10],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adven[pc].status[7] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item (mixed_gworld,source_rects[11],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[11],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adven[pc].status[8] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item (mixed_gworld,source_rects[12],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[12],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adven[pc].status[9] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item (mixed_gworld,source_rects[13],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[13],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adven[pc].status[10] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item (mixed_gworld,source_rects[14],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[14],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adven[pc].status[11] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item (mixed_gworld,source_rects[15],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[15],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adven[pc].status[12] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item (mixed_gworld,source_rects[16],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[16],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adven[pc].status[13] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item (mixed_gworld,source_rects[17],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,source_rects[17],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
@@ -1431,13 +1431,13 @@ void print_buf ()
 	to_rect.bottom = to_rect.top + 128;
 	from_rect = to_rect;
 	OffsetRect(&from_rect,-1 * from_rect.left,-1 * from_rect.top);
-	rect_draw_some_item(status_pattern_gworld,from_rect,
+	rect_draw_some_item_bmp(status_pattern_gworld,from_rect,
 		text_area_gworld,to_rect,0,0);
 	to_rect = erase_rect;
 	to_rect.top = to_rect.bottom - 8;
 	from_rect = to_rect;
 	OffsetRect(&from_rect,-1 * from_rect.left,-1 * from_rect.top);
-	rect_draw_some_item(status_pattern_gworld,from_rect,
+	rect_draw_some_item_bmp(status_pattern_gworld,from_rect,
 		text_area_gworld,to_rect,0,0);
 
 
@@ -1484,7 +1484,7 @@ void print_buf ()
 
 	OffsetRect(&dest_rect,TEXT_WIN_UL_X,TEXT_WIN_UL_Y);
  	// Now put text on window.
-	rect_draw_some_item (text_area_gworld, store_text_rect, text_area_gworld, dest_rect, 0, 1);
+	rect_draw_some_item_bmp(text_area_gworld, store_text_rect, text_area_gworld, dest_rect, 0, 1);
 	string_added = FALSE;	
 }
 
@@ -1543,7 +1543,7 @@ RECT	destrec = {0,0,28,36};
 	terrain_there[target.x][target.y] = -1;
 	
 	destrec = coord_to_rect(target.x,target.y);
-	rect_draw_some_item ( src_gworld,  src_rect,   targ_gworld, 
+	rect_draw_some_item_bmp(src_gworld,  src_rect,   targ_gworld,
 		destrec,   masked,  main_win);
 
 }

--- a/src/Windows Code Release 3/town.cpp
+++ b/src/Windows Code Release 3/town.cpp
@@ -1612,7 +1612,7 @@ void draw_map (HWND the_dialog, short the_item)
 			//old_brush = SelectObject(hdc2,bg[0]);
 			//old_pen = SelectObject(hdc2,GetStockObject(NULL_PEN));
 			//Rectangle(hdc2,whole_map_win_rect.left, whole_map_win_rect.top,whole_map_win_rect.right,whole_map_win_rect.bottom);
-			paint_pattern(hdc2,2,whole_map_win_rect,0);
+			paint_pattern_dc(hdc2,whole_map_win_rect,0);
 			//SelectObject(hdc2,old_brush);
 			//SelectObject(hdc2,old_pen);
 			SetBkMode(hdc2,TRANSPARENT);

--- a/src/Windows Code Release 3/town.cpp
+++ b/src/Windows Code Release 3/town.cpp
@@ -20,8 +20,10 @@
 #include "fields.h"
 #include "locutils.h"
 #include "dlogtool.h"
+#include "dlogtool_helpers.hpp"
 #include "infodlgs.h"
 #include "graphutl.h"
+#include "graphutl_helpers.hpp"
 
 extern HBITMAP mixed_gworld,spec_scen_g;
 extern current_town_type far c_town;
@@ -1541,7 +1543,7 @@ void draw_map (HWND the_dialog, short the_item)
 								custom_from = coord_to_rect(pic % 10, pic / 10);
 								OffsetRect(&custom_from,-13,-13);
 								SelectObject(hdc,old_bmp);
-								rect_draw_some_item(spec_scen_g,custom_from,map_gworld,draw_rect,0,0);
+								rect_draw_some_item_bmp(spec_scen_g,custom_from,map_gworld,draw_rect,0,0);
  								SelectObject(hdc,map_gworld);
 								}
 							}
@@ -1553,7 +1555,7 @@ void draw_map (HWND the_dialog, short the_item)
 									else OffsetRect(&ter_temp_from,
 										24 * ((terrain_pic[what_ter] - 400) / 5) + 312,6 * ((terrain_pic[what_ter] - 400) % 5) + 163);
 								SelectObject(hdc,old_bmp);
-								rect_draw_some_item(mixed_gworld,ter_temp_from,
+								rect_draw_some_item_bmp(mixed_gworld,ter_temp_from,
 									map_gworld,draw_rect,0,0);
 								SelectObject(hdc,map_gworld);
 								break;
@@ -1584,7 +1586,7 @@ void draw_map (HWND the_dialog, short the_item)
 									138 + 6 * ((map_pats[what_ter] - 30) % 5));
 								//OffsetRect(&ter_temp_from,0,115);
 								SelectObject(hdc,old_bmp);
-								rect_draw_some_item(mixed_gworld,ter_temp_from,
+								rect_draw_some_item_bmp(mixed_gworld,ter_temp_from,
 									map_gworld,draw_rect,0,0);
 								SelectObject(hdc,map_gworld);
 								break;
@@ -1627,7 +1629,7 @@ void draw_map (HWND the_dialog, short the_item)
 			InvalidateRect(GetDlgItem(the_dialog,1),&draw_rect,FALSE);
 			}
 
-		rect_draw_some_item(map_gworld,area_to_draw_from,hdc2,area_to_draw_on,0,2);
+		rect_draw_some_item_dc(map_gworld,area_to_draw_from,hdc2,area_to_draw_on,0,2);
 		}
 
 	// Now place PCs and monsters

--- a/src/Windows Code Release 3/town.cpp
+++ b/src/Windows Code Release 3/town.cpp
@@ -1697,8 +1697,7 @@ void draw_map (HWND the_dialog, short the_item)
 
 		// graphics goes here
 		if ((draw_surroundings == TRUE) || (the_item != 5)) { // redraw much stuff
-			draw_dialog_graphic(the_dialog, dlogpicrect,
-				721, FALSE,0); // draw the map graphic
+			draw_dialog_graphic_wnd(the_dialog, dlogpicrect, 721, FALSE); // draw the map graphic
 			}
 		}
 }


### PR DESCRIPTION
These are cases where at the call site the same function was being called with different windows GDI handle types and usually some kind of additional parameter which tells the underlying function what the type of the parameter is.
The three functions where this is exhibited are:
1. draw_dialog_graphic
2. rect_draw_some_item
3. paint_pattern
The way to get to allow C++ to compile this would be to explicitly cast but this is pretty messy and will hinder refactoring. Instead I provided wrapper function variants which take the specific handle type and then they cast it to the expected type.
I named these variants according to the type provided (assuming it is known), so functions ending _wnd, _dc, _bmp, etc.
These should all be no effect changes, because at this point in time we're just trying to get it cleanly building rather than to do any more exotic refactoring.