### PR TITLE
Move Window function signatures to match WNDPROC/DLGPROC and use HINS…

### DIFF
--- a/src/Windows Code Release 3/PC editor/bladpced.cpp
+++ b/src/Windows Code Release 3/PC editor/bladpced.cpp
@@ -156,7 +156,8 @@ HBITMAP bmap = NULL;
 HPALETTE hpal;
 PALETTEENTRY far ape[256];
 HDC main_dc,main_dc2,main_dc3;
-HANDLE store_hInstance,accel;
+HINSTANCE store_hInstance;
+HACCEL accel;
 BOOL event_handled;
 
 char szWinName[] = "Blades of Exile dialogs";
@@ -168,10 +169,10 @@ Boolean block_erase = FALSE;
 #include "itemdata.h"
 
 
-long FAR PASCAL WndProc (HWND, UINT, UINT, LONG);
+LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 Boolean handle_menu (short, HMENU);
 
-int PASCAL WinMain(HANDLE hInstance, HANDLE hPrevInstance, LPSTR lpszCmdParam, int nCmdShow)
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpszCmdParam, int nCmdShow)
 {
 
 	MSG msg;
@@ -277,7 +278,7 @@ int PASCAL WinMain(HANDLE hInstance, HANDLE hPrevInstance, LPSTR lpszCmdParam, i
 		return msg.wParam;
 }
 
-long FAR PASCAL WndProc(HWND hwnd, UINT message, UINT wParam, LONG lParam)
+LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
 HDC hdc;
 PAINTSTRUCT ps;

--- a/src/Windows Code Release 3/PC editor/dlogtool.cpp
+++ b/src/Windows Code Release 3/PC editor/dlogtool.cpp
@@ -24,8 +24,7 @@ extern HFONT fantasy_font,font,italic_font,underline_font,bold_font,tiny_font,sm
 extern HWND mainPtr;
 extern HPALETTE hpal;
 extern HDC main_dc;
-extern HANDLE store_hInstance;
-long FAR PASCAL WndProc (HWND, UINT, UINT, LONG);
+extern HINSTANCE store_hInstance;
 extern HBRUSH bg[14];
 
 // Necessary evil
@@ -39,7 +38,7 @@ extern HBITMAP startmsc_gworld;
 extern short far terrain_pic[256];
 extern short ulx,uly;
 
-extern HANDLE accel;
+extern HACCEL accel;
 extern unsigned char m_pic_index_x[200];
 extern unsigned char m_pic_index_y[200];
 extern unsigned char m_pic_index[200];
@@ -69,7 +68,7 @@ Boolean far label_taken[NL];
 
 HWND edit_box = NULL;
 HWND store_edit_parent; // kludgy
-FARPROC edit_proc,old_edit_proc;
+WNDPROC edit_proc,old_edit_proc;
 
 HDC dlg_force_dc = NULL; // save HDCs when dealing with dlogs
 
@@ -156,12 +155,10 @@ short button_ul_y[15] = {0,0,132,23,46, 69,46,69,36,36, 36,23,92,92,0};
 short button_width[15] = {23,63,102,16,63, 63,63,63,6,14, 14,63,63,63,30};
 short button_height[15] = {23,23,23,13,23, 23,23,23,6,10,10,23,40,40,30};
 
-BOOL FAR PASCAL dummy_dialog_proc
-	(HWND hDlg, UINT message, UINT wParam, LONG lParam);
-long FAR PASCAL fresh_edit_proc(HWND hwnd, UINT message, UINT wParam, LONG lParam);
+INT_PTR CALLBACK dummy_dialog_proc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
+LRESULT CALLBACK fresh_edit_proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 
-
-	FARPROC d_proc;
+DLGPROC d_proc;
 
 extern char szAppName[];
 extern char szWinName[];
@@ -182,11 +179,11 @@ void cd_init_dialogs()
 	for (i = 0; i < NL; i++) {
 		label_taken[i] = FALSE;
 		}
-	d_proc = MakeProcInstance((FARPROC) dummy_dialog_proc,store_hInstance);
-	edit_proc = MakeProcInstance ((FARPROC) fresh_edit_proc,store_hInstance);
+	d_proc = dummy_dialog_proc;
+	edit_proc = fresh_edit_proc;
 }
 
-long FAR PASCAL fresh_edit_proc(HWND hwnd, UINT message, UINT wParam, LONG lParam)
+LRESULT CALLBACK fresh_edit_proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
 
 	switch (message) {
@@ -527,8 +524,8 @@ short cd_create_dialog(short dlog_num,HWND parent)
 	return 0;
 }
 
-BOOL FAR PASCAL dummy_dialog_proc
-	(HWND hDlg, UINT message, UINT wParam, LONG lParam) {
+INT_PTR CALLBACK dummy_dialog_proc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+{
 	short i,j,k,free_slot = -1,free_item = -1,type,flag;
 	char item_str[256];
 	Boolean str_stored = FALSE;
@@ -721,7 +718,7 @@ BOOL FAR PASCAL dummy_dialog_proc
 								max(22,item_rect[free_item].bottom - item_rect[free_item].top),
 								dlgs[free_slot],150,store_hInstance,NULL);
 							store_edit_parent =  dlgs[free_slot];
-							old_edit_proc = (FARPROC) GetWindowLongPtr(edit_box,GWLP_WNDPROC);
+							old_edit_proc = reinterpret_cast<WNDPROC>(GetWindowLongPtr(edit_box,GWLP_WNDPROC));
 							SetWindowLongPtr(edit_box,GWLP_WNDPROC,reinterpret_cast<LONG_PTR>(edit_proc));
 
 							break;

--- a/src/Windows Code Release 3/PC editor/editors.cpp
+++ b/src/Windows Code Release 3/PC editor/editors.cpp
@@ -45,11 +45,11 @@ extern short store_trait_mode;
 pc_record_type *store_pc;
 HBITMAP button_num_gworld;
 
-FARPROC dlog_proc1;
+DLGPROC dlog_proc1;
 HWND test_dlog3;
 short answer_given;
 HWND store_focus;
-extern HANDLE store_hInstance;
+extern HINSTANCE store_hInstance;
 
 void combine_things(short pc_num)
 {
@@ -240,8 +240,7 @@ short select_pc(short active_only,short free_inv_only)
 }
 
 
-BOOL FAR PASCAL choice_dialog_proc
-	(HWND hDlg, UINT message, UINT wParam, LONG lParam) {
+INT_PTR CALLBACK choice_dialog_proc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam) {
 	RECT to_rect = {8,8,44,44};
 	short i;
 	Boolean do_stnd = TRUE;
@@ -274,7 +273,7 @@ short choice_dialog(short pic,short num)
 	char dlog_name[10];
 
 	store_focus = GetFocus();
-	dlog_proc1 = MakeProcInstance((FARPROC) choice_dialog_proc,store_hInstance);
+	dlog_proc1 = choice_dialog_proc;
 	if (dlog_proc1 == NULL) {
 		add_string_to_buf("Dialog error, number...");
 		//print_nums(0,0,num);

--- a/src/Windows Code Release 3/PC editor/edsound.cpp
+++ b/src/Windows Code Release 3/PC editor/edsound.cpp
@@ -12,7 +12,7 @@
 HGLOBAL sound_handles[NUM_SOUNDS];
 char far *snds[NUM_SOUNDS];
 
-extern HANDLE store_hInstance;
+extern HINSTANCE store_hInstance;
 
 extern Boolean play_sounds,in_startup_mode;
 extern HWND mainPtr;

--- a/src/Windows Code Release 3/PC editor/graphics.cpp
+++ b/src/Windows Code Release 3/PC editor/graphics.cpp
@@ -59,7 +59,7 @@ extern RECT pc_status_rect[10];
 extern RECT traits_rect;
 extern RECT pc_traits_rect[16]; 
 extern RECT edit_rect[5][2]; 
-extern HANDLE store_hInstance;
+extern HINSTANCE store_hInstance;
 
 short store_str1a;
 short store_str1b;

--- a/src/Windows Code Release 3/Scen Ed/blscened.cpp
+++ b/src/Windows Code Release 3/Scen Ed/blscened.cpp
@@ -121,7 +121,8 @@ HBITMAP bmap = NULL;
 HPALETTE hpal;
 PALETTEENTRY far ape[256];
 HDC main_dc,main_dc2,main_dc3;
-HANDLE store_hInstance,accel;
+HINSTANCE store_hInstance;
+HACCEL accel;
 BOOL event_handled;
 
 scenario_data_type far scenario;
@@ -152,10 +153,10 @@ Boolean block_erase = FALSE;
 
 
 
-long FAR PASCAL WndProc (HWND, UINT, UINT, LONG);
+LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 Boolean handle_menu (short, HMENU);
 
-int PASCAL WinMain(HANDLE hInstance, HANDLE hPrevInstance, LPSTR lpszCmdParam, int nCmdShow)
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpszCmdParam, int nCmdShow)
 {
 	MSG msg;
 	WNDCLASS wndclass,wndclass2;
@@ -288,7 +289,7 @@ int PASCAL WinMain(HANDLE hInstance, HANDLE hPrevInstance, LPSTR lpszCmdParam, i
 		return msg.wParam;
 }
 
-long FAR PASCAL WndProc(HWND hwnd, UINT message, UINT wParam, LONG lParam)
+LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
 HDC hdc;
 PAINTSTRUCT ps;

--- a/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
+++ b/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
@@ -22,8 +22,7 @@ extern HFONT font,italic_font,underline_font,bold_font,tiny_font,small_bold_font
 extern HWND mainPtr;
 extern HPALETTE hpal;
 extern HDC main_dc;
-extern HANDLE store_hInstance;
-long FAR PASCAL WndProc (HWND, UINT, UINT, LONG);
+extern HINSTANCE store_hInstance;
 
 
 extern short far terrain_pic[256];
@@ -31,7 +30,7 @@ extern unsigned char m_pic_index[200];
 extern unsigned char m_pic_index_x[200];
 extern unsigned char m_pic_index_y[200];
 
-extern HANDLE accel;
+extern HACCEL accel;
 
 short current_key = 0;
 short far dlg_keys[ND];
@@ -60,7 +59,7 @@ HWND edit_box[80];
 HWND store_edit_parent[80];
 short store_edit_parent_num[80];
 short store_edit_item[80]; // kludgy
-FARPROC edit_proc,old_edit_proc[80];
+WNDPROC edit_proc,old_edit_proc[80];
 
 HDC dlg_force_dc = NULL; // save HDCs when dealing with dlogs
 
@@ -141,12 +140,11 @@ short button_ul_y[15] = {0,0,132,23,46, 69,46,69,36,36, 36,23,92,92,0};
 short button_width[15] = {23,63,102,16,63, 63,63,63,6,14, 14,63,63,63,30};
 short button_height[15] = {23,23,23,13,23, 23,23,23,6,10,10,23,40,40,30};
 
-BOOL FAR PASCAL dummy_dialog_proc
-	(HWND hDlg, UINT message, UINT wParam, LONG lParam);
-long FAR PASCAL fresh_edit_proc(HWND hwnd, UINT message, UINT wParam, LONG lParam);
+INT_PTR CALLBACK dummy_dialog_proc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
+LRESULT CALLBACK fresh_edit_proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 
-	FARPROC d_proc;
+DLGPROC d_proc;
 
 extern char szAppName[];
 extern char szWinName[];
@@ -173,11 +171,11 @@ void cd_init_dialogs()
 		store_edit_parent_num[i] = -1;
 		store_edit_item[i] = -1	;
 		}
-	d_proc = MakeProcInstance((FARPROC) dummy_dialog_proc,store_hInstance);
-		edit_proc = MakeProcInstance ((FARPROC) fresh_edit_proc,store_hInstance);
+	d_proc = dummy_dialog_proc;
+	edit_proc = fresh_edit_proc;
 }
 
-long FAR PASCAL fresh_edit_proc(HWND hwnd, UINT message, UINT wParam, LONG lParam)
+LRESULT CALLBACK fresh_edit_proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
 	short i,cur_box = -1,cur_item_num,item_for_focus = -1,first_edit_box = -1;
 
@@ -348,8 +346,8 @@ short cd_create_dialog(short dlog_num,HWND parent)
 	return 0;
 }
 
-BOOL FAR PASCAL dummy_dialog_proc
-	(HWND hDlg, UINT message, UINT wParam, LONG lParam) {
+INT_PTR CALLBACK dummy_dialog_proc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+{
 	short i,j,k,l,free_slot = -1,free_item = -1,type,flag;
 	char item_str[256];
 	Boolean str_stored = FALSE,focus_set = FALSE;
@@ -554,7 +552,7 @@ BOOL FAR PASCAL dummy_dialog_proc
 									store_edit_parent[l] =  dlgs[free_slot];
  									store_edit_parent_num[l] = store_dlog_num;
 									store_edit_item[l] = i;
-									old_edit_proc[l] = (FARPROC) GetWindowLongPtr(edit_box[l],GWLP_WNDPROC);
+									old_edit_proc[l] = reinterpret_cast<WNDPROC>(GetWindowLongPtr(edit_box[l],GWLP_WNDPROC));
 									SetWindowLongPtr(edit_box[l],GWL_WNDPROC,reinterpret_cast<LONG_PTR>(edit_proc));
 									if (focus_set == FALSE) {
 										SetFocus(edit_box[l]);
@@ -1306,7 +1304,7 @@ HWND edit_box[80];
 HWND store_edit_parent[80];
 short store_edit_parent_num[80];
 short store_edit_item[80]; // kludgy
-FARPROC edit_proc,old_edit_proc[80];
+DLGPROC edit_proc,old_edit_proc[80];
 */
 void cd_frame_item(short dlog_num, short item_num, short width)
 {

--- a/src/Windows Code Release 3/Scen Ed/edsound.cpp
+++ b/src/Windows Code Release 3/Scen Ed/edsound.cpp
@@ -12,7 +12,7 @@
 HGLOBAL sound_handles[NUM_SOUNDS];
 char far *snds[NUM_SOUNDS];
 
-extern HANDLE store_hInstance;
+extern HINSTANCE store_hInstance;
 
 extern Boolean play_sounds,in_startup_mode;
 extern HWND mainPtr;

--- a/src/Windows Code Release 3/Scen Ed/graphics.cpp
+++ b/src/Windows Code Release 3/Scen Ed/graphics.cpp
@@ -52,7 +52,8 @@ extern unsigned char m_pic_index[200];
 extern char *button_strs[140];
 extern location cur_out;
 extern short ulx,uly;
-extern  HANDLE store_hInstance,accel;
+extern HINSTANCE store_hInstance;
+extern HACCEL accel;
 
 short num_ir[3] = {12,10,4};
 

--- a/src/Windows Code Release 3/Scen Ed/keydlgs.cpp
+++ b/src/Windows Code Release 3/Scen Ed/keydlgs.cpp
@@ -22,7 +22,7 @@ extern special_node_type null_spec_node;
 extern talking_node_type null_talk_node;
 extern piles_of_stuff_dumping_type *data_store;
 extern outdoor_record_type far current_terrain;
-extern HANDLE store_hInstance;
+extern HINSTANCE store_hInstance;
 
 extern char far scen_strs[160][256];
 extern char far scen_strs2[110][256];

--- a/src/Windows Code Release 3/blades.cpp
+++ b/src/Windows Code Release 3/blades.cpp
@@ -170,14 +170,15 @@ short store_pc_being_created;
 HWND	mainPtr;
 HWND force_dlog = NULL;
 HFONT font,fantasy_font,small_bold_font,italic_font,underline_font,bold_font,tiny_font;
-FARPROC modeless_dlogprocs[18] = {NULL,	NULL,	NULL,	NULL,	NULL,	NULL,
+DLGPROC modeless_dlogprocs[18] = {NULL,	NULL,	NULL,	NULL,	NULL,	NULL,
 								NULL,	NULL,	NULL,	NULL,	NULL,	NULL,
 								NULL,	NULL,	NULL,	NULL,	NULL,	NULL};
 HBITMAP bmap = NULL;
 HPALETTE hpal;
 PALETTEENTRY far ape[256];
 HDC main_dc,main_dc2,main_dc3;
-HANDLE store_hInstance,accel;
+HINSTANCE store_hInstance;
+HACCEL accel;
 BOOL event_handled;
 scenario_data_type far scenario;
 piles_of_stuff_dumping_type *data_store;
@@ -194,11 +195,11 @@ char szAppName[] = "Blades of Exile";
 char file_path_name[256];
 
 Boolean block_erase = FALSE;
+LRESULT CALLBACK WndProc(HWND, UINT, WPARAM, LPARAM);
 
-long FAR PASCAL WndProc (HWND, UINT, UINT, LONG);
 Boolean handle_menu (short, HMENU);
 
-int PASCAL WinMain(HANDLE hInstance, HANDLE hPrevInstance, LPSTR lpszCmdParam, int nCmdShow)
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpszCmdParam, int nCmdShow)
 {
 
 	MSG msg;
@@ -396,7 +397,7 @@ int PASCAL WinMain(HANDLE hInstance, HANDLE hPrevInstance, LPSTR lpszCmdParam, i
 		return msg.wParam;
 }
 
-long FAR PASCAL WndProc(HWND hwnd, UINT message, UINT wParam, LONG lParam)
+LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
 HDC hdc;
 PAINTSTRUCT ps;

--- a/src/Windows Code Release 3/dlogtool.cpp
+++ b/src/Windows Code Release 3/dlogtool.cpp
@@ -28,8 +28,7 @@ extern HFONT fantasy_font,font,italic_font,underline_font,bold_font,tiny_font,sm
 extern HWND mainPtr;
 extern HPALETTE hpal;
 extern HDC main_dc;
-extern HANDLE store_hInstance;
-long FAR PASCAL WndProc (HWND, UINT, UINT, LONG);
+extern HINSTANCE store_hInstance;
 extern Boolean modeless_exists[18];
 extern HWND modeless_dialogs[18];
 extern HBRUSH bg[14];
@@ -45,7 +44,7 @@ extern HBITMAP startmsc_gworld;
 extern short far terrain_pic[256];
 
 
-extern HANDLE accel;
+extern HACCEL accel;
 extern unsigned char m_pic_index_x[200];
 extern unsigned char m_pic_index_y[200];
 extern unsigned char m_pic_index[200];
@@ -75,7 +74,7 @@ Boolean far label_taken[NL];
 
 HWND edit_box = NULL;
 HWND store_edit_parent; // kludgy
-FARPROC edit_proc,old_edit_proc;
+WNDPROC edit_proc,old_edit_proc;
 
 HDC dlg_force_dc = NULL; // save HDCs when dealing with dlogs
 
@@ -162,12 +161,11 @@ short button_ul_y[15] = {0,0,132,23,46, 69,46,69,36,36, 36,23,92,92,0};
 short button_width[15] = {23,63,102,16,63, 63,63,63,6,14, 14,63,63,63,30};
 short button_height[15] = {23,23,23,13,23, 23,23,23,6,10,10,23,40,40,30};
 
-BOOL FAR PASCAL dummy_dialog_proc
-	(HWND hDlg, UINT message, UINT wParam, LONG lParam);
-long FAR PASCAL fresh_edit_proc(HWND hwnd, UINT message, UINT wParam, LONG lParam);
+INT_PTR CALLBACK dummy_dialog_proc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
+LRESULT CALLBACK fresh_edit_proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 
-	FARPROC d_proc;
+DLGPROC d_proc;
 
 extern char szAppName[];
 extern char szWinName[];
@@ -188,11 +186,11 @@ void cd_init_dialogs()
 	for (i = 0; i < NL; i++) {
 		label_taken[i] = FALSE;
 		}
-	d_proc = MakeProcInstance((FARPROC) dummy_dialog_proc,store_hInstance);
-	edit_proc = MakeProcInstance ((FARPROC) fresh_edit_proc,store_hInstance);
+	d_proc = dummy_dialog_proc;
+	edit_proc = fresh_edit_proc;
 }
 
-long FAR PASCAL fresh_edit_proc(HWND hwnd, UINT message, UINT wParam, LONG lParam)
+LRESULT CALLBACK fresh_edit_proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
 
 	switch (message) {
@@ -536,8 +534,7 @@ short cd_create_dialog(short dlog_num,HWND parent)
 	return 0;
 }
 
-BOOL FAR PASCAL dummy_dialog_proc
-	(HWND hDlg, UINT message, UINT wParam, LONG lParam) {
+INT_PTR CALLBACK dummy_dialog_proc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam) {
 	short i,j,k,free_slot = -1,free_item = -1,type,flag;
 	char item_str[256];
 	Boolean str_stored = FALSE;
@@ -730,7 +727,7 @@ BOOL FAR PASCAL dummy_dialog_proc
 								item_rect[free_item].bottom - item_rect[free_item].top,
 								dlgs[free_slot],150,store_hInstance,NULL);
 							store_edit_parent =  dlgs[free_slot];
-							old_edit_proc = (FARPROC) GetWindowLongPtr(edit_box,GWLP_WNDPROC);
+							old_edit_proc = reinterpret_cast<WNDPROC>(GetWindowLongPtr(edit_box,GWLP_WNDPROC));
 							SetWindowLongPtr(edit_box,GWLP_WNDPROC,reinterpret_cast<LONG_PTR>(edit_proc));
 
 							break;

--- a/src/Windows Code Release 3/exlsound.cpp
+++ b/src/Windows Code Release 3/exlsound.cpp
@@ -14,7 +14,7 @@
 HGLOBAL sound_handles[NUM_SOUNDS];
 char far *snds[NUM_SOUNDS];
 
-extern HANDLE store_hInstance;
+extern HINSTANCE store_hInstance;
 extern scenario_data_type far scenario;
 
 extern Boolean play_sounds,in_startup_mode;

--- a/src/Windows Code Release 3/graphics.cpp
+++ b/src/Windows Code Release 3/graphics.cpp
@@ -66,7 +66,7 @@ extern HDC main_dc,main_dc2,main_dc3;
 extern HFONT fantasy_font,font,small_bold_font,italic_font,underline_font,bold_font;
 extern HCURSOR arrow_curs[3][3], sword_curs, key_curs, target_curs,talk_curs,look_curs;
 
-extern HANDLE store_hInstance;
+extern HINSTANCE store_hInstance;
 extern Boolean modeless_exists[18],diff_depth_ok;
 extern short modeless_key[18];
 extern HWND modeless_dialogs[18];

--- a/src/Windows Code Release 3/items.cpp
+++ b/src/Windows Code Release 3/items.cpp
@@ -29,7 +29,7 @@ extern current_town_type far c_town;
 extern town_item_list far 	t_i;
 extern HWND mainPtr;
 extern Boolean in_startup_mode,boom_anim_active;
-  extern HANDLE store_hInstance;
+extern HINSTANCE store_hInstance;
 
 extern pc_record_type far adven[6];
 extern big_tr_type far  t_d;
@@ -41,7 +41,7 @@ extern short modeless_key[18];
 extern HWND modeless_dialogs[18];
 extern short town_size[3];
 extern short town_type;
-	extern FARPROC modeless_dlogprocs[18];
+extern DLGPROC modeless_dlogprocs[18];
 extern short dialog_answer;
 extern Boolean cd_event_filter();
 extern Boolean dialog_not_toast;
@@ -71,7 +71,7 @@ short store_dnum;
 
 HWND test_dlog3;
 HWND store_focus;
-FARPROC dlog_proc1;
+DLGPROC dlog_proc1;
 
 short being_created;
 short procinst_exists[18] = {0,0,0,0,0, 0,0,0,0,0 ,0,0,0,0,0, 0,0,0};
@@ -1237,8 +1237,7 @@ short get_num_of_items(short max_num)
 	return dialog_answer;
 }
 
-BOOL FAR PASCAL choice_dialog_proc
-	(HWND hDlg, UINT message, UINT wParam, LONG lParam) {
+INT_PTR CALLBACK choice_dialog_proc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam) {
 	RECT to_rect = {8,8,44,44};
 	short i;
 	Boolean do_stnd = TRUE;
@@ -1271,7 +1270,7 @@ short choice_dialog(short pic,short num)
 	char dlog_name[10];
 
 	store_focus = GetFocus();
-	dlog_proc1 = MakeProcInstance((FARPROC) choice_dialog_proc,store_hInstance);
+	dlog_proc1 = choice_dialog_proc;
 	if (dlog_proc1 == NULL) {
 		add_string_to_buf("Dialog error, number...");
 		print_nums(0,0,num);
@@ -1285,8 +1284,7 @@ short choice_dialog(short pic,short num)
 }
 
 
-BOOL FAR PASCAL modeless_dialog_proc
-	(HWND hDlg, UINT message, UINT wParam, LONG lParam) {
+INT_PTR CALLBACK modeless_dialog_proc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam) {
 	short i,which_d,store_which;
 	char item_str[256];
 	Boolean do_stnd = TRUE,id_dlg = TRUE;
@@ -1332,7 +1330,6 @@ BOOL FAR PASCAL modeless_dialog_proc
 void create_modeless_dialog(short which_dlog)
 {
 	short i,which_d;
-	FARPROC d_proc;
 
 	for (i = 0; i < 18; i++)
 		if (which_dlog == modeless_key[i]) {
@@ -1351,7 +1348,7 @@ void create_modeless_dialog(short which_dlog)
 	modeless_exists[which_d] = TRUE;
 	if (procinst_exists[which_d] == 0) {
 		procinst_exists[which_d] = 1;
-		modeless_dlogprocs[which_d] = MakeProcInstance((FARPROC) modeless_dialog_proc,store_hInstance);
+		modeless_dlogprocs[which_d] = modeless_dialog_proc;
 		}
 	modeless_dialogs[which_d] = CreateDialog(store_hInstance,
 	 MAKEINTRESOURCE(which_dlog),mainPtr,modeless_dlogprocs[which_d]);

--- a/src/Windows Code Release 3/text.cpp
+++ b/src/Windows Code Release 3/text.cpp
@@ -111,7 +111,7 @@ extern location ok_space[4];
 extern HFONT font,italic_font,underline_font,bold_font,small_bold_font;
 extern HPALETTE hpal;
 extern HDC main_dc;
-extern HANDLE store_hInstance;
+extern HINSTANCE store_hInstance;
 extern piles_of_stuff_dumping_type5 *data_store5;
 
 short current_item_button[6] = {-1,-1,-1,-1,-1,-1};

--- a/src/Windows Code Release 3/town.cpp
+++ b/src/Windows Code Release 3/town.cpp
@@ -72,7 +72,7 @@ extern short special_queue[20];
 extern HPALETTE hpal;
 extern far PALETTEENTRY ape[256];
 extern HDC main_dc,main_dc2,main_dc3;
-extern HANDLE store_hInstance;
+extern HINSTANCE store_hInstance;
 extern stored_town_maps_type far town_maps,town_maps2;
 extern piles_of_stuff_dumping_type *data_store;
 extern piles_of_stuff_dumping_type2 *data_store2;
@@ -80,7 +80,7 @@ extern stored_town_maps_type far town_maps,town_maps2;
 
 extern short ulx,uly;
 
-FARPROC map_proc = NULL;
+DLGPROC map_proc = NULL;
 
 // extra devices for maps
 	HBRUSH hbrush[6] = {NULL, NULL, NULL, NULL, NULL, NULL};
@@ -1706,8 +1706,7 @@ void draw_map (HWND the_dialog, short the_item)
 
 
 
-BOOL FAR PASCAL map_dialog_proc
-	(HWND hDlg, UINT message, UINT wParam, LONG lParam) {
+INT_PTR CALLBACK map_dialog_proc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam) {
 	short i,which_d,store_which;
 	char item_str[256];
 	Boolean do_stnd = TRUE,id_dlg = TRUE;
@@ -1768,7 +1767,7 @@ void display_map()
 	
 	modeless_exists[5] = TRUE;
 	if (map_proc == NULL) {
-		map_proc = MakeProcInstance((FARPROC) map_dialog_proc,store_hInstance);
+		map_proc = map_dialog_proc;
 		}
 	modeless_dialogs[5] = CreateDialog(store_hInstance,
 	 MAKEINTRESOURCE(1046),mainPtr,map_proc);


### PR DESCRIPTION
…TANCE and HACCEL instead of HANDLE

MakeProcInstance also disappears, see: https://devblogs.microsoft.com/oldnewthing/20080207-00/?p=23533

WNDPROC/DLGPROC function signatures changed to match accordingly, and variables changed to use those types.

Windows HINSTANCE/HACCEL now correctly typed rather than being HANDLE.

FARPROC and PASCAL gone!