### PR TITLE
Build the app and tools using clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,34 @@ if (MSVC)
 	# largely because they aren't portable and in any case we'll be migrating such
 	# functionality to leverage the C++ STL in good time.
 	add_definitions(-DNOMINMAX -D_CRT_SECURE_NO_WARNINGS)
+
+	if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		# Warnings which are going to be more involved to address either because of
+		# the complexity, or the number of places it touches.
+		add_compile_options(
+			-Wno-writable-strings
+			-Wno-extern-initializer
+			-Wno-unused-variable
+			-Wno-char-subscripts
+			-Wno-misleading-indentation
+			-Wno-unused-but-set-variable
+			-Wno-constant-conversion
+			-Wno-sometimes-uninitialized
+		)
+		# Warnings which either should be addressed ASAP or are trivial to address
+		add_compile_options(
+			-Wno-format
+			-Wno-empty-body
+			-Wno-unused-value
+			-Wno-comment
+			-Wno-parentheses
+			-Wno-missing-braces
+			-Wno-tautological-overlap-compare
+			-Wno-tautological-constant-compare
+			-Wno-pointer-to-int-cast
+			-Wno-nonportable-include-path
+		)
+	endif()
 endif()
 
 add_subdirectory(src)

--- a/src/Windows Code Release 3/party.cpp
+++ b/src/Windows Code Release 3/party.cpp
@@ -1,5 +1,6 @@
 
 #include <Windows.h>
+#include <cassert>
 #include "stdio.h"
 
 #include "global.h"
@@ -3598,7 +3599,10 @@ void kill_pc(short which_pc,short type)
 		current_pc = first_active_pc();
 	if (current_pc > 5) {
 		for (i = 0; i < 6; i++)
-			if (adven[i].status > 0)
+			// Original line read: if (adven[i].status > 0)
+			// But status is an array of shorts, so lets assume they meant main_status and check later
+			assert(false);
+			if (adven[i].main_status > 0)
 				current_pc = i;
 		}
 	put_pc_screen();


### PR DESCRIPTION
clang-cl is a strange creature "neither fish nor fowl", as they say. However it does do a fantastic job at detecting code smells and hopefully prepare us for the eventual point where we can build parts of the code for a platform other than Windows. I should probably avoid setting both Windows warning flags and clang-cl ones, but for now we're still at the: get it to build. There are two lists of warnings, the first looked like they might take some effort to address and perhaps aren't as serious as the second set. The second set are either serious enough to do something about or trivial enough to address easily. One bug came out which is described here: https://github.com/CorrodedCoder/Blades-of-Exile/issues/20. The workaround for now is to assert so that we can evaluate it at runtime and leave a comment about the mystery.