### PR TITLE
Unsafe graphics types refactored

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ if (MSVC)
 		else()
 			# This is our default settings for the builds
 			add_compile_options(
+				-ferror-limit=1000
 				# default to all warnings
 				-Wall
 

--- a/src/Windows Code Release 3/PC editor/dlogtool.cpp
+++ b/src/Windows Code Release 3/PC editor/dlogtool.cpp
@@ -1751,27 +1751,37 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 		return;
 		}
 
+	RectDrawDestination draw_dest;
+	if (win_or_gworld == 1)
+	{
+		draw_dest = std::get<HBITMAP>(hDlg);
+	}
+	else
+	{
+		draw_dest = hdc;
+	}
+
 	switch (which_g / 100) {
 
 		case 7: // dialog
 				which_g -= 700;
 			from_gworld = dlogpics_gworld;
 			OffsetRect(&from2,36 * (which_g % 4),36 * (which_g / 4));
-			rect_draw_some_item_either(from_gworld,from2,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from2, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 11: // item info help
 			from_rect = item_info_from;
 			rect.right = rect.left + from_rect.right - from_rect.left;
 			rect.bottom = rect.top + from_rect.bottom - from_rect.top;
-			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(mixed_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 12: // item info help
 			from_rect = pc_info_from;
 			rect.right = rect.left + pc_info_from.right - pc_info_from.left;
 			rect.bottom = rect.top + pc_info_from.bottom - pc_info_from.top;
-			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(mixed_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 14: // button help
@@ -1780,7 +1790,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				from_gworld = load_pict(900 + which_g,hdc);
 				from_rect = large_scen_from;
 				OffsetRect(&from_rect,64 * (which_g % 10),0);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+				rect_draw_some_item(from_gworld,from_rect, draw_dest
 				  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				break;
@@ -1791,7 +1801,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			rect.right = rect.left + from_rect.right;
 			rect.bottom = rect.top + from_rect.bottom;
 			OffsetRect(&from_rect,0,100 * which_g);
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
@@ -1805,7 +1815,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			OffsetRect(&from_rect,32 * (which_g % 5),32 * (which_g / 5));
 			rect.right = rect.left + 32;
 			rect.bottom = rect.top + 32;
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;

--- a/src/Windows Code Release 3/PC editor/dlogtool.cpp
+++ b/src/Windows Code Release 3/PC editor/dlogtool.cpp
@@ -1722,11 +1722,9 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 	RECT large_scen_from = {0,0,64,64};
 
 	HBITMAP from_gworld;
-	short draw_dest = 2;
 	HDC hdc;
 
-	if (win_or_gworld == 1)
-		draw_dest = 0;
+	const short draw_dest = (win_or_gworld == 1) ? 0 : 2;
 
 	if (which_g < 0)
 		return;

--- a/src/Windows Code Release 3/PC editor/dlogtool.cpp
+++ b/src/Windows Code Release 3/PC editor/dlogtool.cpp
@@ -1695,7 +1695,7 @@ void frame_dlog_rect(HWND hDlg, RECT rect, short val)
 	DeleteObject(lpen);
 }
 
-void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld)
+void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld)
 // win_or_gworld: 0 - window  1 - an HBITMAP
 //    1 means hDlg is actually an HBITMAP variable!
 // 0 - 300   number of terrain graphic
@@ -1738,7 +1738,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 	if (win_or_gworld == 0) {
 		if (dlg_force_dc != NULL)
 			hdc = dlg_force_dc;
-			else hdc = GetDC(hDlg);
+			else hdc = GetDC(std::get<HWND>(hDlg));
 		SelectPalette(hdc,hpal,0);
 		}
 	if (which_g == 950) { // Empty. Maybe clear space.
@@ -1751,7 +1751,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			}
 			//FillCRect(&rect,bg[5]);	// don't forget to nail dc!!!
 		if (dlg_force_dc == NULL)
-			fry_dc(hDlg, hdc);
+			fry_dc(std::get<HWND>(hDlg), hdc);
 		return;
 		}
 
@@ -1819,10 +1819,10 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 		}
 
 	if ((win_or_gworld == 0) && (dlg_force_dc == NULL))
-		fry_dc(hDlg, hdc);
+		fry_dc(std::get<HWND>(hDlg), hdc);
 	if ((win_or_gworld == 0) && (do_frame == TRUE)){
 		rect.bottom--; rect.right--;
-		frame_dlog_rect(hDlg,rect,3);
+		frame_dlog_rect(std::get<HWND>(hDlg),rect,3);
 		}
 }
 

--- a/src/Windows Code Release 3/PC editor/dlogtool.cpp
+++ b/src/Windows Code Release 3/PC editor/dlogtool.cpp
@@ -1724,8 +1724,6 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 	HBITMAP from_gworld;
 	HDC hdc;
 
-	const short draw_dest = (win_or_gworld == 1) ? 0 : 2;
-
 	if (which_g < 0)
 		return;
 
@@ -1760,21 +1758,21 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			from_gworld = dlogpics_gworld;
 			OffsetRect(&from2,36 * (which_g % 4),36 * (which_g / 4));
 			rect_draw_some_item_either(from_gworld,from2,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 11: // item info help
 			from_rect = item_info_from;
 			rect.right = rect.left + from_rect.right - from_rect.left;
 			rect.bottom = rect.top + from_rect.bottom - from_rect.top;
 			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 12: // item info help
 			from_rect = pc_info_from;
 			rect.right = rect.left + pc_info_from.right - pc_info_from.left;
 			rect.bottom = rect.top + pc_info_from.bottom - pc_info_from.top;
 			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 14: // button help
 			which_g -= 1400;
@@ -1783,7 +1781,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				from_rect = large_scen_from;
 				OffsetRect(&from_rect,64 * (which_g % 10),0);
 				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-				  ,rect,0,draw_dest);
+				  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				break;
 				}
@@ -1794,7 +1792,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			rect.bottom = rect.top + from_rect.bottom;
 			OffsetRect(&from_rect,0,100 * which_g);
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 
@@ -1808,7 +1806,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			rect.right = rect.left + 32;
 			rect.bottom = rect.top + 32;
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 

--- a/src/Windows Code Release 3/PC editor/dlogtool.h
+++ b/src/Windows Code Release 3/PC editor/dlogtool.h
@@ -1,3 +1,9 @@
+#pragma once
+
+#include <variant>
+
+using DialogDrawDestination = std::variant<HWND, HBITMAP>;
+
 void cd_set_flag(short dlog_num,short item_num,short flag);
 void cd_erase_rect(short dlog_num,RECT to_fry);
 short cd_get_led(short dlog_num,short item_num);
@@ -39,7 +45,7 @@ short cd_get_item_id(short dlg_num, short item_num);
 void center_window(HWND window);
 RECT get_item_rect(HWND hDlg, short item_num);
 void frame_dlog_rect(HWND hDlg, RECT rect, short val);
-void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld);
+void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld);
 
 inline void draw_dialog_graphic_wnd(HWND hDlg, RECT rect, short which_g, Boolean do_frame)
 {

--- a/src/Windows Code Release 3/PC editor/graphics.cpp
+++ b/src/Windows Code Release 3/PC editor/graphics.cpp
@@ -318,7 +318,7 @@ void draw_main_screen()
 
 
 	// TODO: Oddity: should probably be changed to 1, but currently benign
-	paint_pattern(NULL,3,whole_win_rect,3);
+	paint_pattern(std::monostate{}, 3, whole_win_rect, 3);
 
 	dest_rec = source_rect = title_from;
 	OffsetRect(&dest_rec,20,6);

--- a/src/Windows Code Release 3/PC editor/graphutl.cpp
+++ b/src/Windows Code Release 3/PC editor/graphutl.cpp
@@ -459,7 +459,7 @@ HBITMAP load_pict(short pict_num,HDC model_hdc)
 	return got_bitmap;
 }
 
-void rect_draw_some_item(HBITMAP src,RECT src_rect, HBITMAP dest,RECT dest_rect,
+void rect_draw_some_item(HBITMAP src,RECT src_rect, RectDrawDestination dest,RECT dest_rect,
 	short trans, short main_win) {
 	HDC hdcMem,hdcMem2,hdcMem3,destDC;
 	HBITMAP transbmp;
@@ -472,7 +472,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, HBITMAP dest,RECT dest_rect,
 	Boolean dlog_draw = FALSE;
 
 	if (main_win == 2) {
-		destDC = (HDC)dest;
+		destDC = std::get<HDC>(dest);
 		main_win = 1;
 		dlog_draw = TRUE;
 		hdcMem = CreateCompatibleDC(destDC);
@@ -489,7 +489,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, HBITMAP dest,RECT dest_rect,
 	if (trans != 1) {
 		if (main_win == 0) { // Not transparent, into bitmap
 			hdcMem2 = main_dc3;
-			store2 = SelectObject(hdcMem2, dest);
+			store2 = SelectObject(hdcMem2, std::get<HBITMAP>(dest));
 			/*CreateCompatibleDC(hdcMem);
 			SelectObject(hdcMem2, dest);
 			SetMapMode(hdcMem2,GetMapMode(mainPtr));
@@ -530,7 +530,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, HBITMAP dest,RECT dest_rect,
 		else {
 		if (main_win == 0) {
 			hdcMem3 = CreateCompatibleDC(hdcMem);
-			SelectObject(hdcMem3, dest);
+			SelectObject(hdcMem3, std::get<HBITMAP>(dest));
 			SetMapMode(hdcMem3,GetMapMode(GetDC(mainPtr)));
 			SelectPalette(hdcMem3,hpal,0);
 			transbmp = CreateBitmap(src_rect.right - src_rect.left,

--- a/src/Windows Code Release 3/PC editor/graphutl.cpp
+++ b/src/Windows Code Release 3/PC editor/graphutl.cpp
@@ -618,7 +618,7 @@ void DisposeGWorld(HBITMAP bitmap)
 // is 1 ... ignore dest ... paint on mainPtr
 // is 2 ... dest is a dialog, use the dialog pattern
 // both pattern gworlds are 192 x 256
-void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_pattern)
+void paint_pattern(PaintDrawDestination dest,short which_mode,RECT dest_rect,short which_pattern)
 {
 	HBITMAP source_pat;
 	RECT pattern_source = {32,168,96,232}, pat_dest_orig = {0,0,64,64},pat_dest;
@@ -677,13 +677,13 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 				switch (which_mode) {
 					case 0:
 						rect_draw_some_item_bmp(source_pat,draw_from,
-							dest,draw_to,0,0); break;
+							std::get<HBITMAP>(dest),draw_to,0,0); break;
 					case 1:
 						rect_draw_some_item_bmp(source_pat,draw_from,
 							source_pat,draw_to,0,1); break;
 					case 2:
-						rect_draw_some_item_bmp(source_pat,draw_from,
-							dest,draw_to,0,2); break;
+						rect_draw_some_item_dc(source_pat,draw_from,
+							std::get<HDC>(dest),draw_to,0,2); break;
 					}
 				}
 			}

--- a/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
+++ b/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
@@ -1685,6 +1685,8 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 		do_frame = FALSE;
 	which_g = which_g % 2000;
 
+	assert(win_or_gworld == 0);
+
 	if (win_or_gworld == 0) {
 		if (dlg_force_dc != NULL)
 			hdc = dlg_force_dc;
@@ -1718,7 +1720,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				rect.left += 1;
 				rect.right = rect.left + 28;
 				}
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect,hdc
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
@@ -1730,7 +1732,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				}
 			from_gworld = load_pict(820, main_dc);
 			from_rect = calc_rect(4 * (which_g / 5), which_g % 5);
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, hdc
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
@@ -1749,7 +1751,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 					Rectangle(hdc,rect.left,rect.top,rect.right,rect.bottom);
 					SelectObject(hdc,old_brush);
 					}
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 1)) {
 				rect.right = rect.left + 28; rect.bottom = rect.top + 36;
@@ -1762,13 +1764,13 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left,rect.top + 7);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc, small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, hdc, small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 			if ((m_pic_index_x[which_g] == 1) && (m_pic_index_y[which_g] == 2)) {
 				rect.right = rect.left + 28; rect.bottom = rect.top + 36;
@@ -1781,13 +1783,13 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left + 7,rect.top);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,0,18);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 2)) {
@@ -1801,25 +1803,25 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left,rect.top);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 2;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,-14,18);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 3;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 
 			break;
@@ -1850,7 +1852,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 					from_rect = tiny_obj_rect;
 					OffsetRect(&from_rect,18 * (which_g % 10), 18 * (which_g / 10));
 					}
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, hdc
 			  ,to_rect,1, (win_or_gworld == 1) ? 0 : 2);
 			break;
 
@@ -1858,7 +1860,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				which_g -= 700;
 			from_gworld = dlogpics_gworld;
 			OffsetRect(&from2,36 * (which_g % 4),36 * (which_g / 4));
-			rect_draw_some_item_either(from_gworld,from2,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from2, hdc
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 
@@ -1867,20 +1869,20 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			from_gworld = talkfaces_gworld;
 			from_rect = face_from;
 			OffsetRect(&from_rect,32 * ((which_g - 1) % 10),32 * ((which_g - 1) / 10));
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
+			rect_draw_some_item(from_gworld,from_rect, hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 11: // item info help
 			from_rect = item_info_from;
 			rect.right = rect.left + from_rect.right - from_rect.left;
 			rect.bottom = rect.top + from_rect.bottom - from_rect.top;
-			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(mixed_gworld,from_rect, hdc
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 12: // item info help
 			from_rect = pc_info_from;
 			rect.right = rect.left + pc_info_from.right - pc_info_from.left;
 			rect.bottom = rect.top + pc_info_from.bottom - pc_info_from.top;
-			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(mixed_gworld,from_rect, hdc
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 16:
@@ -1891,7 +1893,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			OffsetRect(&from_rect,32 * (which_g % 5),32 * (which_g / 5));
 			rect.right = rect.left + 32;
 			rect.bottom = rect.top + 32;
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, hdc
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DisposeGWorld(from_gworld);
 			break;

--- a/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
+++ b/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
@@ -1673,13 +1673,12 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 	RECT item_info_from = {174,0,312,112};
 
 	HBITMAP from_gworld;
-	short draw_dest = 2,m_start_pic;
+	short m_start_pic;
 	HDC hdc;
 	HGDIOBJ old_brush;
 	RECT small_monst_rect = {0,0,14,18};
 
-	if (win_or_gworld == 1)
-		draw_dest = 0;
+	const short draw_dest = (win_or_gworld == 1) ? 0 : 2;
 
 	if (which_g < 0)
 		return;

--- a/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
+++ b/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
@@ -1678,8 +1678,6 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 	HGDIOBJ old_brush;
 	RECT small_monst_rect = {0,0,14,18};
 
-	const short draw_dest = (win_or_gworld == 1) ? 0 : 2;
-
 	if (which_g < 0)
 		return;
 
@@ -1721,7 +1719,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				rect.right = rect.left + 28;
 				}
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 3: // animated terrain
@@ -1733,7 +1731,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			from_gworld = load_pict(820, main_dc);
 			from_rect = calc_rect(4 * (which_g / 5), which_g % 5);
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 4: case 5: // monster
@@ -1753,7 +1751,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 					}
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 1)) {
 				rect.right = rect.left + 28; rect.bottom = rect.top + 36;
@@ -1769,7 +1767,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
@@ -1778,7 +1776,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				OffsetRect(&small_monst_rect,14,0);
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 			if ((m_pic_index_x[which_g] == 1) && (m_pic_index_y[which_g] == 2)) {
 				rect.right = rect.left + 28; rect.bottom = rect.top + 36;
@@ -1794,7 +1792,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
@@ -1803,7 +1801,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 2)) {
@@ -1820,7 +1818,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
@@ -1830,7 +1828,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 
 				m_start_pic = m_pic_index[which_g] + 2;
 				from_gworld = monst_gworld[m_start_pic / 20];
@@ -1840,7 +1838,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 3;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
@@ -1849,7 +1847,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 
 			break;
@@ -1881,7 +1879,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 					OffsetRect(&from_rect,18 * (which_g % 10), 18 * (which_g / 10));
 					}
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,to_rect,1,draw_dest);
+			  ,to_rect,1, (win_or_gworld == 1) ? 0 : 2);
 			break;
 
 		case 7: // dialog
@@ -1889,7 +1887,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			from_gworld = dlogpics_gworld;
 			OffsetRect(&from2,36 * (which_g % 4),36 * (which_g / 4));
 			rect_draw_some_item_either(from_gworld,from2,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 
 		case 10: // talk face
@@ -1899,21 +1897,21 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			OffsetRect(&from_rect,32 * ((which_g - 1) % 10),32 * ((which_g - 1) / 10));
 			if (win_or_gworld == 1)
 				 rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
-				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0,draw_dest);
+				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 11: // item info help
 			from_rect = item_info_from;
 			rect.right = rect.left + from_rect.right - from_rect.left;
 			rect.bottom = rect.top + from_rect.bottom - from_rect.top;
 			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 12: // item info help
 			from_rect = pc_info_from;
 			rect.right = rect.left + pc_info_from.right - pc_info_from.left;
 			rect.bottom = rect.top + pc_info_from.bottom - pc_info_from.top;
 			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 16:
 			which_g -= 1600;
@@ -1924,7 +1922,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			rect.right = rect.left + 32;
 			rect.bottom = rect.top + 32;
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DisposeGWorld(from_gworld);
 			break;
 		}

--- a/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
+++ b/src/Windows Code Release 3/Scen Ed/dlogtool.cpp
@@ -1749,9 +1749,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 					Rectangle(hdc,rect.left,rect.top,rect.right,rect.bottom);
 					SelectObject(hdc,old_brush);
 					}
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 1)) {
 				rect.right = rect.left + 28; rect.bottom = rect.top + 36;
@@ -1764,19 +1762,13 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left,rect.top + 7);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
-
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc, small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 			if ((m_pic_index_x[which_g] == 1) && (m_pic_index_y[which_g] == 2)) {
 				rect.right = rect.left + 28; rect.bottom = rect.top + 36;
@@ -1789,19 +1781,13 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left + 7,rect.top);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,0,18);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 2)) {
@@ -1815,39 +1801,25 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left,rect.top);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
-
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
-
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 2;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,-14,18);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 3;
 				from_gworld = monst_gworld[m_start_pic / 20];
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 
 			break;
@@ -1895,9 +1867,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			from_gworld = talkfaces_gworld;
 			from_rect = face_from;
 			OffsetRect(&from_rect,32 * ((which_g - 1) % 10),32 * ((which_g - 1) / 10));
-			if (win_or_gworld == 1)
-				 rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
-				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 11: // item info help
 			from_rect = item_info_from;

--- a/src/Windows Code Release 3/Scen Ed/graphutl.cpp
+++ b/src/Windows Code Release 3/Scen Ed/graphutl.cpp
@@ -468,7 +468,7 @@ HBITMAP load_pict(short pict_num, HDC model_hdc)
 	return got_bitmap;
 }
 
-void rect_draw_some_item(HBITMAP src,RECT src_rect, HBITMAP dest,RECT dest_rect,
+void rect_draw_some_item(HBITMAP src,RECT src_rect, RectDrawDestination dest,RECT dest_rect,
 	short trans, short main_win) {
 	HDC hdcMem,hdcMem2,hdcMem3,destDC;
 	HBITMAP transbmp;
@@ -490,7 +490,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, HBITMAP dest,RECT dest_rect,
 	SetStretchBltMode(main_dc3,STRETCH_DELETESCANS);
 
 	if (main_win == 2) {
-		destDC = (HDC)dest;
+		destDC = std::get<HDC>(dest);
 		main_win = 1;
 		dlog_draw = TRUE;
 		hdcMem = CreateCompatibleDC(destDC);
@@ -511,7 +511,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, HBITMAP dest,RECT dest_rect,
 	if (trans != 1) {
 		if (main_win == 0) { // Not transparent, into bitmap
 			hdcMem2 = main_dc3;
-			store2 = SelectObject(hdcMem2, dest);
+			store2 = SelectObject(hdcMem2, std::get<HBITMAP>(dest));
 			/*CreateCompatibleDC(hdcMem);
 			SelectObject(hdcMem2, dest);
 			SetMapMode(hdcMem2,GetMapMode(mainPtr));
@@ -557,7 +557,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, HBITMAP dest,RECT dest_rect,
 		else {
 		if (main_win == 0) {
 			hdcMem3 = CreateCompatibleDC(hdcMem);
-			SelectObject(hdcMem3, dest);
+			SelectObject(hdcMem3, std::get<HBITMAP>(dest));
 			SetMapMode(hdcMem3,GetMapMode(GetDC(mainPtr)));
 			SelectPalette(hdcMem3,hpal,0);
 			transbmp = CreateBitmap(src_rect.right - src_rect.left,

--- a/src/Windows Code Release 3/Scen Ed/graphutl.cpp
+++ b/src/Windows Code Release 3/Scen Ed/graphutl.cpp
@@ -647,7 +647,7 @@ void DisposeGWorld(HBITMAP bitmap)
 // is 1 ... ignore dest ... paint on mainPtr
 // is 2 ... dest is a dialog, use the dialog pattern
 // both pattern gworlds are 192 x 256
-void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_pattern)
+void paint_pattern(PaintDrawDestination dest,short which_mode,RECT dest_rect,short which_pattern)
 {
 	HBITMAP source_pat;
 	RECT pattern_source = {32,168,96,232}, pat_dest_orig = {0,0,64,64},pat_dest;
@@ -706,13 +706,13 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 				switch (which_mode) {
 					case 0:
 						rect_draw_some_item_bmp(source_pat,draw_from,
-							dest,draw_to,0,0); break;
+							std::get<HBITMAP>(dest),draw_to,0,0); break;
 					case 1:
 						rect_draw_some_item_bmp(source_pat,draw_from,
 							source_pat,draw_to,0,1); break;
 					case 2:
-						rect_draw_some_item_bmp(source_pat,draw_from,
-							dest,draw_to,0,2); break;
+						rect_draw_some_item_dc(source_pat,draw_from,
+							std::get<HDC>(dest),draw_to,0,2); break;
 					}
 				}
 			}

--- a/src/Windows Code Release 3/dlogtool.cpp
+++ b/src/Windows Code Release 3/dlogtool.cpp
@@ -1749,13 +1749,11 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 	RECT large_scen_from = {0,0,64,64};
 
 	HBITMAP from_gworld;
-	short draw_dest = 2;
 	HDC hdc;
 	HGDIOBJ old_brush;
 	short m_start_pic = 0,square_size = 32;
 
-	if (win_or_gworld == 1)
-		draw_dest = 0;
+	const short draw_dest = (win_or_gworld == 1) ? 0 : 2;
 
 	if (which_g < 0)
 		return;

--- a/src/Windows Code Release 3/dlogtool.cpp
+++ b/src/Windows Code Release 3/dlogtool.cpp
@@ -1715,7 +1715,7 @@ void frame_dlog_rect(HWND hDlg, RECT rect, short val)
 	DeleteObject(lpen);
 }
 
-void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld)
+void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld)
 // win_or_gworld: 0 - window  1 - an HBITMAP
 //    1 means hDlg is actually an HBITMAP variable!
 // 0 - 300   number of terrain graphic
@@ -1767,7 +1767,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 	if (win_or_gworld == 0) {
 		if (dlg_force_dc != NULL)
 			hdc = dlg_force_dc;
-			else hdc = GetDC(hDlg);
+			else hdc = GetDC(std::get<HWND>(hDlg));
 		SelectPalette(hdc,hpal,0);
 		}
 	if (which_g == 950) { // Empty. Maybe clear space.
@@ -1780,7 +1780,7 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 			}
 			//FillCRect(&rect,bg[5]);	// don't forget to nail dc!!!
 		if (dlg_force_dc == NULL)
-			fry_dc(hDlg, hdc);
+			fry_dc(std::get<HWND>(hDlg), hdc);
 		return;
 		}
 
@@ -2111,10 +2111,10 @@ void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,s
 		}
 
 	if ((win_or_gworld == 0) && (dlg_force_dc == NULL))
-		fry_dc(hDlg, hdc);
+		fry_dc(std::get<HWND>(hDlg), hdc);
 	if ((win_or_gworld == 0) && (do_frame == TRUE)){
 		rect.bottom--; rect.right--;
-		frame_dlog_rect(hDlg,rect,3);
+		frame_dlog_rect(std::get<HWND>(hDlg),rect,3);
 		}
 }
 

--- a/src/Windows Code Release 3/dlogtool.cpp
+++ b/src/Windows Code Release 3/dlogtool.cpp
@@ -1815,9 +1815,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 					Rectangle(hdc,rect.left,rect.top,rect.right,rect.bottom);
 					SelectObject(hdc,old_brush);
 					}
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				}
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 1)) {
@@ -1831,21 +1829,14 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left,rect.top + 7);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
-
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				}
 			if ((m_pic_index_x[which_g] == 1) && (m_pic_index_y[which_g] == 2)) {
@@ -1860,20 +1851,14 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left + 7,rect.top);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg, hdc, small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,0,18);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				}
 
@@ -1888,42 +1873,28 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left,rect.top);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
-
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
-
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 2;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,-14,18);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 3;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-
-				if (win_or_gworld == 1)
-					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 				DeleteObject(from_gworld);
 			break;
@@ -1975,9 +1946,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			from_gworld = load_pict(875,main_dc);
 			from_rect = bw_from;
 			OffsetRect(&from_rect,120 * ((which_g) % 3),120 * ((which_g) / 3));
-			if (win_or_gworld == 1)
-				 rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
-				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 10: // talk face
@@ -1985,9 +1954,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			from_gworld = load_pict(860,main_dc);
 			from_rect = face_from;
 			OffsetRect(&from_rect,32 * ((which_g - 1) % 10),32 * ((which_g - 1) / 10));
-			if (win_or_gworld == 1)
-				 rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
-				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
+			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 11: // item info help  

--- a/src/Windows Code Release 3/dlogtool.cpp
+++ b/src/Windows Code Release 3/dlogtool.cpp
@@ -1780,6 +1780,15 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 		return;
 		}
 
+	RectDrawDestination draw_dest;
+	if (win_or_gworld == 1)
+	{
+		draw_dest = std::get<HBITMAP>(hDlg);
+	}
+	else
+	{
+		draw_dest = hdc;
+	}
 	switch (which_g / 100) {
 		case 0: case 1: case 2: // terrain
 			from_gworld = load_pict(800 + which_g / 50,main_dc);
@@ -1789,7 +1798,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				rect.left += 1;
             rect.right = rect.left + 28;
 				}
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
@@ -1797,7 +1806,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			which_g -= 300;
 			from_gworld = load_pict(820,main_dc);
 			from_rect = calc_rect(4 * (which_g / 5), which_g % 5);
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
@@ -1815,7 +1824,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 					Rectangle(hdc,rect.left,rect.top,rect.right,rect.bottom);
 					SelectObject(hdc,old_brush);
 					}
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, draw_dest,rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				}
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 1)) {
@@ -1829,14 +1838,14 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left,rect.top + 7);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, draw_dest,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, draw_dest,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				}
 			if ((m_pic_index_x[which_g] == 1) && (m_pic_index_y[which_g] == 2)) {
@@ -1851,14 +1860,14 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left + 7,rect.top);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg, hdc, small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, draw_dest,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,0,18);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, draw_dest,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				}
 
@@ -1873,28 +1882,28 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,rect.left,rect.top);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, draw_dest,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, draw_dest,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 2;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,-14,18);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, draw_dest,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 3;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
 				m_start_pic = m_start_pic % 20;
 				from_rect = calc_rect(2 * (m_start_pic / 10), m_start_pic % 10);
 				OffsetRect(&small_monst_rect,14,0);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
+				rect_draw_some_item(from_gworld,from_rect, draw_dest,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 				DeleteObject(from_gworld);
 			break;
@@ -1916,14 +1925,14 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 					from_rect = tiny_obj_rect;
 					OffsetRect(&from_rect,18 * (which_g % 10), 18 * (which_g / 10));
 					}
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,to_rect,1, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 7: // dialog
 				which_g -= 700;
 			from_gworld = dlogpics_gworld;
 			OffsetRect(&from2,36 * (which_g % 4),36 * (which_g / 4));
-			rect_draw_some_item_either(from_gworld,from2,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from2, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 8: // PC
@@ -1936,7 +1945,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			Rectangle(hdc,rect.left,rect.top,rect.right,rect.bottom);
 			SelectObject(hdc,old_brush);
 			//PaintRect(&rect);
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,rect,1, (win_or_gworld == 1) ? 0 : 2);
 			if (pcs_gworld == NULL)
 				DeleteObject(from_gworld);
@@ -1946,7 +1955,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			from_gworld = load_pict(875,main_dc);
 			from_rect = bw_from;
 			OffsetRect(&from_rect,120 * ((which_g) % 3),120 * ((which_g) / 3));
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
+			rect_draw_some_item(from_gworld,from_rect, draw_dest,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 10: // talk face
@@ -1954,21 +1963,21 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			from_gworld = load_pict(860,main_dc);
 			from_rect = face_from;
 			OffsetRect(&from_rect,32 * ((which_g - 1) % 10),32 * ((which_g - 1) / 10));
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
+			rect_draw_some_item(from_gworld,from_rect, draw_dest,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 11: // item info help  
 			from_rect = item_info_from;
 			rect.right = rect.left + from_rect.right - from_rect.left;
 			rect.bottom = rect.top + from_rect.bottom - from_rect.top;
-			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(mixed_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 12: // item info help  
 			from_rect = pc_info_from;
 			rect.right = rect.left + pc_info_from.right - pc_info_from.left;
 			rect.bottom = rect.top + pc_info_from.bottom - pc_info_from.top;
-			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(mixed_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 14: // button help
@@ -1977,7 +1986,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				from_gworld = load_pict(900 + which_g,main_dc);
 				from_rect = large_scen_from;
 				OffsetRect(&from_rect,64 * (which_g % 10),0);
-				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+				rect_draw_some_item(from_gworld,from_rect, draw_dest
 				  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				break;
@@ -1988,7 +1997,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			rect.right = rect.left + from_rect.right;
 			rect.bottom = rect.top + from_rect.bottom;
 			OffsetRect(&from_rect,0,100 * which_g);
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
@@ -1997,7 +2006,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			from_rect = combat_ap_from;
 			rect.right = rect.left + from_rect.right;
 			rect.bottom = rect.top + from_rect.bottom;
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
@@ -2006,7 +2015,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			from_rect = stat_symbols_from;
 			rect.right = rect.left + from_rect.right;
 			rect.bottom = rect.top + from_rect.bottom;
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
@@ -2018,7 +2027,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			OffsetRect(&from_rect,32 * (which_g % 5),32 * (which_g / 5));
 			rect.right = rect.left + 32;
 			rect.bottom = rect.top + 32;
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
@@ -2033,7 +2042,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 
 				//PaintRect(&rect);
 				}
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 20: case 21: case 22: case 23: // dialog
@@ -2048,7 +2057,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				SelectObject(hdc,old_brush);
 				}
 
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,rect,(do_frame == FALSE) ? 1 : 0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 24: case 25: case 26: case 27: // dialog
@@ -2062,13 +2071,13 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			to_rect.bottom = to_rect.top + square_size;
 			from_rect.right = from_rect.left + square_size / 2;
 			from_rect.bottom = from_rect.top + square_size;
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,to_rect,1, (win_or_gworld == 1) ? 0 : 2);
 			from_rect = get_custom_rect(which_g + 1);
 			OffsetRect(&to_rect,square_size / 2,0);
 			from_rect.right = from_rect.left + square_size / 2;
 			from_rect.bottom = from_rect.top + square_size;
-			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
+			rect_draw_some_item(from_gworld,from_rect, draw_dest
 			  ,to_rect,1, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		}

--- a/src/Windows Code Release 3/dlogtool.cpp
+++ b/src/Windows Code Release 3/dlogtool.cpp
@@ -1753,8 +1753,6 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 	HGDIOBJ old_brush;
 	short m_start_pic = 0,square_size = 32;
 
-	const short draw_dest = (win_or_gworld == 1) ? 0 : 2;
-
 	if (which_g < 0)
 		return;
 
@@ -1792,7 +1790,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
             rect.right = rect.left + 28;
 				}
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 3: // animated terrain
@@ -1800,7 +1798,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			from_gworld = load_pict(820,main_dc);
 			from_rect = calc_rect(4 * (which_g / 5), which_g % 5);
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 4: case 5: // monster
@@ -1819,7 +1817,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 					}
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				}
 			if ((m_pic_index_x[which_g] == 2) && (m_pic_index_y[which_g] == 1)) {
@@ -1836,7 +1834,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
@@ -1847,7 +1845,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				}
 			if ((m_pic_index_x[which_g] == 1) && (m_pic_index_y[which_g] == 2)) {
@@ -1865,7 +1863,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
@@ -1875,7 +1873,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				}
 
@@ -1893,7 +1891,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 
 				m_start_pic = m_pic_index[which_g] + 1;
 				DeleteObject(from_gworld);
@@ -1904,7 +1902,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 
 				m_start_pic = m_pic_index[which_g] + 2;
 				DeleteObject(from_gworld);
@@ -1915,7 +1913,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				m_start_pic = m_pic_index[which_g] + 3;
 				DeleteObject(from_gworld);
 				from_gworld = load_pict(1100 + m_start_pic / 20,main_dc);
@@ -1925,7 +1923,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 
 				if (win_or_gworld == 1)
 					rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,small_monst_rect,0,0);
-					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0,draw_dest);
+					else rect_draw_some_item_dc(from_gworld,from_rect,hdc,small_monst_rect,0, (win_or_gworld == 1) ? 0 : 2);
 				}
 				DeleteObject(from_gworld);
 			break;
@@ -1948,14 +1946,14 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 					OffsetRect(&from_rect,18 * (which_g % 10), 18 * (which_g / 10));
 					}
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,to_rect,1,draw_dest);
+			  ,to_rect,1, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 7: // dialog
 				which_g -= 700;
 			from_gworld = dlogpics_gworld;
 			OffsetRect(&from2,36 * (which_g % 4),36 * (which_g / 4));
 			rect_draw_some_item_either(from_gworld,from2,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 8: // PC
 			if (pcs_gworld != NULL)
@@ -1968,7 +1966,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			SelectObject(hdc,old_brush);
 			//PaintRect(&rect);
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,1,draw_dest);
+			  ,rect,1, (win_or_gworld == 1) ? 0 : 2);
 			if (pcs_gworld == NULL)
 				DeleteObject(from_gworld);
 			break;
@@ -1979,7 +1977,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			OffsetRect(&from_rect,120 * ((which_g) % 3),120 * ((which_g) / 3));
 			if (win_or_gworld == 1)
 				 rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
-				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0,draw_dest);
+				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 10: // talk face
@@ -1989,7 +1987,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			OffsetRect(&from_rect,32 * ((which_g - 1) % 10),32 * ((which_g - 1) / 10));
 			if (win_or_gworld == 1)
 				 rect_draw_some_item_wnd(from_gworld,from_rect,hDlg,rect,0,0);
-				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0,draw_dest);
+				else rect_draw_some_item_dc(from_gworld,from_rect,hdc,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 11: // item info help  
@@ -1997,14 +1995,14 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			rect.right = rect.left + from_rect.right - from_rect.left;
 			rect.bottom = rect.top + from_rect.bottom - from_rect.top;
 			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 12: // item info help  
 			from_rect = pc_info_from;
 			rect.right = rect.left + pc_info_from.right - pc_info_from.left;
 			rect.bottom = rect.top + pc_info_from.bottom - pc_info_from.top;
 			rect_draw_some_item_either(mixed_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 14: // button help
 			which_g -= 1400;
@@ -2013,7 +2011,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				from_rect = large_scen_from;
 				OffsetRect(&from_rect,64 * (which_g % 10),0);
 				rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-				  ,rect,0,draw_dest);
+				  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 				DeleteObject(from_gworld);
 				break;
 				}
@@ -2024,7 +2022,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			rect.bottom = rect.top + from_rect.bottom;
 			OffsetRect(&from_rect,0,100 * which_g);
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 13: // combat ap help  
@@ -2033,7 +2031,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			rect.right = rect.left + from_rect.right;
 			rect.bottom = rect.top + from_rect.bottom;
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 15: // stat symbols help  
@@ -2042,7 +2040,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			rect.right = rect.left + from_rect.right;
 			rect.bottom = rect.top + from_rect.bottom;
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 16: 
@@ -2054,7 +2052,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			rect.right = rect.left + 32;
 			rect.bottom = rect.top + 32;
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			DeleteObject(from_gworld);
 			break;
 		case 17: // dialog
@@ -2069,7 +2067,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				//PaintRect(&rect);
 				}
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,0,draw_dest);
+			  ,rect,0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 20: case 21: case 22: case 23: // dialog
 			which_g -= 2000;
@@ -2084,7 +2082,7 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 				}
 
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,rect,(do_frame == FALSE) ? 1 : 0,draw_dest);
+			  ,rect,(do_frame == FALSE) ? 1 : 0, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		case 24: case 25: case 26: case 27: // dialog
 			which_g -= 2400;
@@ -2098,13 +2096,13 @@ void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, B
 			from_rect.right = from_rect.left + square_size / 2;
 			from_rect.bottom = from_rect.top + square_size;
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,to_rect,1,draw_dest);
+			  ,to_rect,1, (win_or_gworld == 1) ? 0 : 2);
 			from_rect = get_custom_rect(which_g + 1);
 			OffsetRect(&to_rect,square_size / 2,0);
 			from_rect.right = from_rect.left + square_size / 2;
 			from_rect.bottom = from_rect.top + square_size;
 			rect_draw_some_item_either(from_gworld,from_rect,win_or_gworld,hDlg,hdc
-			  ,to_rect,1,draw_dest);
+			  ,to_rect,1, (win_or_gworld == 1) ? 0 : 2);
 			break;
 		}
 

--- a/src/Windows Code Release 3/dlogtool.cpp
+++ b/src/Windows Code Release 3/dlogtool.cpp
@@ -1325,7 +1325,7 @@ void cd_draw_item(short dlog_num,short item_num)
 
 	// hook in special stuff. kludgy
 	if ((dlog_num == 1098) && ((item_num >= 18) && (item_num <= 23))) {
-		draw_pc_effects(10 + item_num - 18,win_dc);
+		draw_pc_effects_dc(item_num - 18,win_dc);
 		}
 
 	SelectObject(win_dc,old_font);

--- a/src/Windows Code Release 3/dlogtool.h
+++ b/src/Windows Code Release 3/dlogtool.h
@@ -1,3 +1,9 @@
+#pragma once
+
+#include <variant>
+
+using DialogDrawDestination = std::variant<HWND, HBITMAP>;
+
 void cd_set_flag(short dlog_num,short item_num,short flag);
 void cd_erase_rect(short dlog_num,RECT to_fry);
 short cd_get_led(short dlog_num,short item_num);
@@ -41,7 +47,7 @@ short cd_get_item_id(short dlg_num, short item_num);
 void center_window(HWND window);
 RECT get_item_rect(HWND hDlg, short item_num);
 void frame_dlog_rect(HWND hDlg, RECT rect, short val);
-void draw_dialog_graphic(HWND hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld);
+void draw_dialog_graphic(DialogDrawDestination hDlg, RECT rect, short which_g, Boolean do_frame,short win_or_gworld);
 void showcursor(Boolean a);
 
 void cd_get_text_edit_str(short dlog_num, char *str);

--- a/src/Windows Code Release 3/dlogtool_helpers.hpp
+++ b/src/Windows Code Release 3/dlogtool_helpers.hpp
@@ -4,7 +4,7 @@
 
 static inline void draw_dialog_graphic_bmp(HBITMAP hBitmap, RECT rect, short which_g, Boolean do_frame)
 {
-	draw_dialog_graphic(reinterpret_cast<HWND>(hBitmap), rect, which_g, do_frame, 1);
+	draw_dialog_graphic(hBitmap, rect, which_g, do_frame, 1);
 }
 
 static inline void draw_dialog_graphic_wnd(HWND hDlg, RECT rect, short which_g, Boolean do_frame)

--- a/src/Windows Code Release 3/graphics.cpp
+++ b/src/Windows Code Release 3/graphics.cpp
@@ -987,7 +987,7 @@ void put_background()
 
 	SelectClipRgn(main_dc,clip_region);
 	GetClientRect(mainPtr,&r);
-	paint_pattern_wnd(mainPtr,r,wp);
+	paint_pattern_main(r,wp);
 	undo_clip();
 
 	//ShowScrollBar(text_sbar,SB_CTL,TRUE);

--- a/src/Windows Code Release 3/graphutl.cpp
+++ b/src/Windows Code Release 3/graphutl.cpp
@@ -623,7 +623,7 @@ void DisposeGWorld(HBITMAP bitmap)
 // is 1 ... ignore dest ... paint on mainPtr
 // is 2 ... dest is a dialog, use the dialog pattern
 // both pattern gworlds are 192 x 256
-void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_pattern)
+void paint_pattern(PaintDrawDestination dest,short which_mode,RECT dest_rect,short which_pattern)
 {
 	HBITMAP source_pat;
 	RECT pattern_source = {32,168,96,232}, pat_dest_orig = {0,0,64,64},pat_dest;
@@ -678,13 +678,13 @@ void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_patt
 				switch (which_mode) {
 					case 0:
 						rect_draw_some_item_bmp(source_pat,draw_from,
-							dest,draw_to,0,0); break;
+							std::get<HBITMAP>(dest),draw_to,0,0); break;
 					case 1:
 						rect_draw_some_item_bmp(source_pat,draw_from,
 							source_pat,draw_to,0,1); break;
 					case 2:
-						rect_draw_some_item_bmp(source_pat,draw_from,
-							dest,draw_to,0,2); break;
+						rect_draw_some_item_dc(source_pat,draw_from,
+							std::get<HDC>(dest),draw_to,0,2); break;
 					}
 				}
 			}

--- a/src/Windows Code Release 3/graphutl.cpp
+++ b/src/Windows Code Release 3/graphutl.cpp
@@ -459,7 +459,7 @@ HBITMAP load_pict(short pict_num, HDC model_hdc)
 	return got_bitmap;
 }
 
-void rect_draw_some_item(HBITMAP src,RECT src_rect,HBITMAP dest,RECT dest_rect,
+void rect_draw_some_item(HBITMAP src,RECT src_rect, RectDrawDestination dest,RECT dest_rect,
 	short trans, short main_win) {
 	HDC hdcMem,hdcMem2,hdcMem3,destDC;
 	HBITMAP transbmp;
@@ -471,7 +471,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect,HBITMAP dest,RECT dest_rect,
 	Boolean dlog_draw = FALSE;
 
 	if (main_win == 2) {
-		destDC = (HDC) dest;
+		destDC = std::get<HDC>(dest);
 		main_win = 1;
 		dlog_draw = TRUE;
 		hdcMem = CreateCompatibleDC(destDC);
@@ -488,7 +488,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect,HBITMAP dest,RECT dest_rect,
 	if (trans != 1) {
 		if (main_win == 0) { // Not transparent, into bitmap
 			hdcMem2 = main_dc3;
-			store2 = SelectObject(hdcMem2, dest);
+			store2 = SelectObject(hdcMem2, std::get<HBITMAP>(dest));
 			/*CreateCompatibleDC(hdcMem);
 			SelectObject(hdcMem2, dest);
 			SetMapMode(hdcMem2,GetMapMode(mainPtr));
@@ -529,7 +529,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect,HBITMAP dest,RECT dest_rect,
 		else {
 		if (main_win == 0) {
 			hdcMem3 = CreateCompatibleDC(hdcMem);
-			SelectObject(hdcMem3, dest);
+			SelectObject(hdcMem3, std::get<HBITMAP>(dest));
 			SetMapMode(hdcMem3,GetMapMode(GetDC(mainPtr)));
 			SelectPalette(hdcMem3,hpal,0);
 			if ((src_rect.right - src_rect.left < 72) &&

--- a/src/Windows Code Release 3/graphutl.h
+++ b/src/Windows Code Release 3/graphutl.h
@@ -3,13 +3,14 @@
 #include <variant>
 
 using PaintDrawDestination = std::variant<HBITMAP, HDC, std::monostate>;
+using RectDrawDestination = std::variant<HBITMAP, HDC>;
 
 void inflict_palette();
 void reset_palette();
 BYTE * GetDibBitsAddr(BYTE * lpDib);
 HBITMAP ReadDib(const char * name,HDC hdc);
 HBITMAP load_pict(short pict_num, HDC model_hdc);
-void rect_draw_some_item(HBITMAP src,RECT src_rect,HBITMAP dest,RECT dest_rect,short trans, short main_win);
+void rect_draw_some_item(HBITMAP src,RECT src_rect, RectDrawDestination dest,RECT dest_rect,short trans, short main_win);
 void fry_dc(HWND hwnd,HDC dc);
 void DisposeGWorld(HBITMAP bitmap);
 void paint_pattern(PaintDrawDestination dest,short which_mode,RECT dest_rect,short which_pattern);

--- a/src/Windows Code Release 3/graphutl.h
+++ b/src/Windows Code Release 3/graphutl.h
@@ -1,3 +1,9 @@
+#pragma once
+
+#include <variant>
+
+using PaintDrawDestination = std::variant<HBITMAP, HDC, std::monostate>;
+
 void inflict_palette();
 void reset_palette();
 BYTE * GetDibBitsAddr(BYTE * lpDib);
@@ -6,4 +12,4 @@ HBITMAP load_pict(short pict_num, HDC model_hdc);
 void rect_draw_some_item(HBITMAP src,RECT src_rect,HBITMAP dest,RECT dest_rect,short trans, short main_win);
 void fry_dc(HWND hwnd,HDC dc);
 void DisposeGWorld(HBITMAP bitmap);
-void paint_pattern(HBITMAP dest,short which_mode,RECT dest_rect,short which_pattern);
+void paint_pattern(PaintDrawDestination dest,short which_mode,RECT dest_rect,short which_pattern);

--- a/src/Windows Code Release 3/graphutl_helpers.hpp
+++ b/src/Windows Code Release 3/graphutl_helpers.hpp
@@ -11,11 +11,6 @@ static inline void rect_draw_some_item_bmp(HBITMAP src, RECT src_rect, HBITMAP d
 	rect_draw_some_item(src, src_rect, dest, dest_rect, trans, main_win);
 }
 
-static inline void rect_draw_some_item_wnd(HBITMAP src,RECT src_rect, DialogDrawDestination dest,RECT dest_rect, short trans, short main_win)
-{
-	rect_draw_some_item(src, src_rect, std::get<HBITMAP>(dest), dest_rect, trans, main_win);
-}
-
 static inline void rect_draw_some_item_dc(HBITMAP src,RECT src_rect,HDC dest,RECT dest_rect, short trans, short main_win)
 {
 	rect_draw_some_item(src, src_rect, dest, dest_rect, trans, main_win);
@@ -25,7 +20,7 @@ static inline void rect_draw_some_item_either(HBITMAP src,RECT src_rect,short wi
 {
 	if(win_or_gworld == 1)
 	{
-		rect_draw_some_item_wnd(src, src_rect, hWnd, dest_rect, trans, main_win);
+		rect_draw_some_item_bmp(src, src_rect, std::get<HBITMAP>(hWnd), dest_rect, trans, main_win);
 	}
 	else
 	{

--- a/src/Windows Code Release 3/graphutl_helpers.hpp
+++ b/src/Windows Code Release 3/graphutl_helpers.hpp
@@ -14,7 +14,7 @@ static inline void rect_draw_some_item_wnd(HBITMAP src,RECT src_rect,HWND dest,R
 
 static inline void rect_draw_some_item_dc(HBITMAP src,RECT src_rect,HDC dest,RECT dest_rect, short trans, short main_win)
 {
-	rect_draw_some_item(src, src_rect, reinterpret_cast<HBITMAP>(dest), dest_rect, trans, main_win);
+	rect_draw_some_item(src, src_rect, dest, dest_rect, trans, main_win);
 }
 
 static inline void rect_draw_some_item_either(HBITMAP src,RECT src_rect,short win_or_gworld, HWND hWnd, HDC hDC,RECT dest_rect, short trans, short main_win)

--- a/src/Windows Code Release 3/graphutl_helpers.hpp
+++ b/src/Windows Code Release 3/graphutl_helpers.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <variant>
+
+using DialogDrawDestination = std::variant<HWND, HBITMAP>;
+
 // Stopgap mechanism to reduce the amount of casting to known places only for now
 
 static inline void rect_draw_some_item_bmp(HBITMAP src, RECT src_rect, HBITMAP dest, RECT dest_rect, short trans, short main_win)
@@ -7,9 +11,9 @@ static inline void rect_draw_some_item_bmp(HBITMAP src, RECT src_rect, HBITMAP d
 	rect_draw_some_item(src, src_rect, dest, dest_rect, trans, main_win);
 }
 
-static inline void rect_draw_some_item_wnd(HBITMAP src,RECT src_rect,HWND dest,RECT dest_rect, short trans, short main_win)
+static inline void rect_draw_some_item_wnd(HBITMAP src,RECT src_rect, DialogDrawDestination dest,RECT dest_rect, short trans, short main_win)
 {
-	rect_draw_some_item(src, src_rect, reinterpret_cast<HBITMAP>(dest), dest_rect, trans, main_win);
+	rect_draw_some_item(src, src_rect, std::get<HBITMAP>(dest), dest_rect, trans, main_win);
 }
 
 static inline void rect_draw_some_item_dc(HBITMAP src,RECT src_rect,HDC dest,RECT dest_rect, short trans, short main_win)
@@ -17,7 +21,7 @@ static inline void rect_draw_some_item_dc(HBITMAP src,RECT src_rect,HDC dest,REC
 	rect_draw_some_item(src, src_rect, dest, dest_rect, trans, main_win);
 }
 
-static inline void rect_draw_some_item_either(HBITMAP src,RECT src_rect,short win_or_gworld, HWND hWnd, HDC hDC,RECT dest_rect, short trans, short main_win)
+static inline void rect_draw_some_item_either(HBITMAP src,RECT src_rect,short win_or_gworld, DialogDrawDestination hWnd, HDC hDC,RECT dest_rect, short trans, short main_win)
 {
 	if(win_or_gworld == 1)
 	{

--- a/src/Windows Code Release 3/graphutl_helpers.hpp
+++ b/src/Windows Code Release 3/graphutl_helpers.hpp
@@ -40,10 +40,10 @@ static inline void paint_pattern_bmp(HBITMAP dest, RECT dest_rect, short which_p
 
 static inline void paint_pattern_main(RECT dest_rect, short which_pattern)
 {
-	paint_pattern(nullptr, 1, dest_rect, which_pattern);
+	paint_pattern(std::monostate{}, 1, dest_rect, which_pattern);
 }
 
 static inline void paint_pattern_dc(HDC dest, RECT dest_rect, short which_pattern)
 {
-	paint_pattern(reinterpret_cast<HBITMAP>(dest), 2, dest_rect, which_pattern);
+	paint_pattern(dest, 2, dest_rect, which_pattern);
 }

--- a/src/Windows Code Release 3/graphutl_helpers.hpp
+++ b/src/Windows Code Release 3/graphutl_helpers.hpp
@@ -47,8 +47,3 @@ static inline void paint_pattern_dc(HDC dest, RECT dest_rect, short which_patter
 {
 	paint_pattern(reinterpret_cast<HBITMAP>(dest), 2, dest_rect, which_pattern);
 }
-
-static inline void paint_pattern_wnd(HWND dest, RECT dest_rect, short which_pattern)
-{
-	paint_pattern(reinterpret_cast<HBITMAP>(dest), 1, dest_rect, which_pattern);
-}

--- a/src/Windows Code Release 3/graphutl_helpers.hpp
+++ b/src/Windows Code Release 3/graphutl_helpers.hpp
@@ -16,18 +16,6 @@ static inline void rect_draw_some_item_dc(HBITMAP src,RECT src_rect,HDC dest,REC
 	rect_draw_some_item(src, src_rect, dest, dest_rect, trans, main_win);
 }
 
-static inline void rect_draw_some_item_either(HBITMAP src,RECT src_rect,short win_or_gworld, DialogDrawDestination hWnd, HDC hDC,RECT dest_rect, short trans, short main_win)
-{
-	if(win_or_gworld == 1)
-	{
-		rect_draw_some_item_bmp(src, src_rect, std::get<HBITMAP>(hWnd), dest_rect, trans, main_win);
-	}
-	else
-	{
-		rect_draw_some_item_dc(src, src_rect, hDC, dest_rect, trans, main_win);
-	}
-}
-
 // which_mode is 0 ... dest is a bitmap
 // is 1 ... ignore dest ... paint on mainPtr
 // is 2 ... dest is a dialog, use the dialog pattern

--- a/src/Windows Code Release 3/text.cpp
+++ b/src/Windows Code Release 3/text.cpp
@@ -807,7 +807,7 @@ const RECT c_source_rects[18] = {
 	BOE_INIT_RECT(115,0,127,12), BOE_INIT_RECT(115,12,127,24), BOE_INIT_RECT(115,24,127,36)
 };
 
-void draw_pc_effects_ex(HBITMAP dest_bmp, short pc, RECT dest_rect, short right_limit, short mode, short dest);
+void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventurer, const RECT& dest_rect_start, short right_limit, short mode, short dest);
 
 void draw_pc_effects(short pc,HDC dest_dc)
 //short pc; // 10 + x -> draw for pc x, but on spell dialog  
@@ -838,90 +838,92 @@ void draw_pc_effects(short pc,HDC dest_dc)
 			dest_rect.bottom += pc * 13;
 			dest_bmp = pc_stats_gworld;
 			}
-	draw_pc_effects_ex(dest_bmp, pc, dest_rect, right_limit, mode, dest);
+	draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
 }
 
-void draw_pc_effects_ex(HBITMAP dest_bmp, short pc, RECT dest_rect, short right_limit, short mode, short dest)
+void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventurer, const RECT& dest_rect_start, short right_limit, short mode, short dest)
 {
-	if (adven[pc].main_status % 10 != 1)
+	RECT dest_rect{ dest_rect_start };
+
+	if (adventurer.main_status % 10 != 1)
 		return;
 			
-	if ((adven[pc].status[0] > 0) && (dest_rect.right < right_limit)) { 
+	if ((adventurer.status[0] > 0) && (dest_rect.right < right_limit)) {
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[4],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
-	if (adven[pc].status[1] > 0) { 
+	if (adventurer.status[1] > 0) {
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[2],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
-	if (adven[pc].status[1] < 0) { 
+	if (adventurer.status[1] < 0) {
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[3],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
-	if (adven[pc].status[2] > 0) { 
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[(adven[pc].status[2] > 4) ? 1 : 0],dest_bmp,dest_rect,mode,dest);
+	if (adventurer.status[2] > 0) {
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[(adventurer.status[2] > 4) ? 1 : 0],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
-	if (adven[pc].status[4] > 0) { 
+	if (adventurer.status[4] > 0) {
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[5],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
-	if (adven[pc].status[3] > 0) { 
+	if (adventurer.status[3] > 0) {
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[6],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
-	if (adven[pc].status[3] < 0) { 
+	if (adventurer.status[3] < 0) {
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[8],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
-	if ((adven[pc].status[5] > 0) && (dest_rect.right < right_limit)) { 
+	if ((adventurer.status[5] > 0) && (dest_rect.right < right_limit)) {
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[9],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
-	if ((adven[pc].status[6] > 0) && (dest_rect.right < right_limit)) { 
+	if ((adventurer.status[6] > 0) && (dest_rect.right < right_limit)) {
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[10],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
-	if ((adven[pc].status[7] > 0) && (dest_rect.right < right_limit)){ 
+	if ((adventurer.status[7] > 0) && (dest_rect.right < right_limit)){
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[11],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
-	if ((adven[pc].status[8] > 0) && (dest_rect.right < right_limit)){ 
+	if ((adventurer.status[8] > 0) && (dest_rect.right < right_limit)){
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[12],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
-	if ((adven[pc].status[9] > 0) && (dest_rect.right < right_limit)){ 
+	if ((adventurer.status[9] > 0) && (dest_rect.right < right_limit)){
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[13],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
-	if ((adven[pc].status[10] > 0) && (dest_rect.right < right_limit)){ 
+	if ((adventurer.status[10] > 0) && (dest_rect.right < right_limit)){
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[14],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
-	if ((adven[pc].status[11] > 0) && (dest_rect.right < right_limit)){ 
+	if ((adventurer.status[11] > 0) && (dest_rect.right < right_limit)){
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[15],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
-	if ((adven[pc].status[12] > 0) && (dest_rect.right < right_limit)){ 
+	if ((adventurer.status[12] > 0) && (dest_rect.right < right_limit)){
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[16],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
-	if ((adven[pc].status[13] > 0) && (dest_rect.right < right_limit)){ 
+	if ((adventurer.status[13] > 0) && (dest_rect.right < right_limit)){
 		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[17],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;

--- a/src/Windows Code Release 3/text.cpp
+++ b/src/Windows Code Release 3/text.cpp
@@ -807,6 +807,7 @@ const RECT c_source_rects[18] = {
 	BOE_INIT_RECT(115,0,127,12), BOE_INIT_RECT(115,12,127,24), BOE_INIT_RECT(115,24,127,36)
 };
 
+// dest: 0 - in gworld  2 - on dialog
 static void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventurer, const RECT& dest_rect_start, short right_limit, short mode, short dest)
 {
 	RECT dest_rect{ dest_rect_start };
@@ -898,38 +899,21 @@ static void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventure
 
 static void draw_pc_effects_dc(short pc, HDC dest_dc)
 {
-	RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27), dlog_dest_rect = BOE_INIT_RECT(66, 354, 78, 366);
-	short right_limit = 250;
-	short dest = 0; // 0 - in gworld  2 - on dialog
-	short mode = 1;
-	HBITMAP dest_bmp;
-
-	right_limit = 490;
-	dest_rect = dlog_dest_rect;
-	dest = 2;
-	mode = 0;
+	RECT dest_rect = BOE_INIT_RECT(66, 354, 78, 366);
 	dest_rect.top += pc * 24 + 18;
 	dest_rect.bottom += pc * 24 + 18;
-	dest_bmp = (HBITMAP)dest_dc;
-	draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
+	draw_pc_effects_ex(reinterpret_cast<HBITMAP>(dest_dc), adven[pc], dest_rect, 490, 0, 2);
 }
 
 static void draw_pc_effects_bmp(short pc, HBITMAP dest_bmp)
 {
+	const short name_width = string_length(adven[pc].name, main_dc);
 	RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27);
-	short right_limit = 250;
-	short dest = 0; // 0 - in gworld  2 - on dialog
-	short name_width, mode = 1;
-
-	name_width = string_length(adven[pc].name, main_dc);
-	right_limit = pc_buttons[0][1].left - 5;
-	//dest_rect.left = pc_buttons[i][1].left - 16;
 	dest_rect.left = name_width + 33;
 	dest_rect.right = dest_rect.left + 12;
 	dest_rect.top += pc * 13;
 	dest_rect.bottom += pc * 13;
-	dest_bmp = pc_stats_gworld;
-	draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
+	draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, pc_buttons[0][1].left - 5, 1, 0);
 }
 
 void draw_pc_effects(short pc, HDC dest_dc)

--- a/src/Windows Code Release 3/text.cpp
+++ b/src/Windows Code Release 3/text.cpp
@@ -807,41 +807,7 @@ const RECT c_source_rects[18] = {
 	BOE_INIT_RECT(115,0,127,12), BOE_INIT_RECT(115,12,127,24), BOE_INIT_RECT(115,24,127,36)
 };
 
-void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventurer, const RECT& dest_rect_start, short right_limit, short mode, short dest);
-
-void draw_pc_effects(short pc,HDC dest_dc)
-//short pc; // 10 + x -> draw for pc x, but on spell dialog  
-{
-	RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27), dlog_dest_rect = BOE_INIT_RECT(66, 354, 78, 366);
-	short right_limit = 250;
-	short dest = 0; // 0 - in gworld  2 - on dialog
-	short name_width,mode = 1;
-	HBITMAP dest_bmp;
-
-	if (pc >= 10) {
-		pc -= 10;
-		right_limit = 490;
-		dest_rect = dlog_dest_rect;
-		dest = 2;
-      mode = 0;
-		dest_rect.top += pc * 24 + 18;
-		dest_rect.bottom += pc * 24 + 18;
-		dest_bmp = (HBITMAP) dest_dc;
-		}
-		else {
-			name_width = string_length(adven[pc].name,main_dc);
-			right_limit = pc_buttons[0][1].left - 5;
-			//dest_rect.left = pc_buttons[i][1].left - 16;
-			dest_rect.left = name_width + 33;
-			dest_rect.right = dest_rect.left + 12;
-			dest_rect.top += pc * 13;
-			dest_rect.bottom += pc * 13;
-			dest_bmp = pc_stats_gworld;
-			}
-	draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
-}
-
-void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventurer, const RECT& dest_rect_start, short right_limit, short mode, short dest)
+static void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventurer, const RECT& dest_rect_start, short right_limit, short mode, short dest)
 {
 	RECT dest_rect{ dest_rect_start };
 
@@ -930,6 +896,37 @@ void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventurer, cons
 		}	
 }
 
+void draw_pc_effects(short pc, HDC dest_dc)
+//short pc; // 10 + x -> draw for pc x, but on spell dialog  
+{
+	RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27), dlog_dest_rect = BOE_INIT_RECT(66, 354, 78, 366);
+	short right_limit = 250;
+	short dest = 0; // 0 - in gworld  2 - on dialog
+	short name_width, mode = 1;
+	HBITMAP dest_bmp;
+
+	if (pc >= 10) {
+		pc -= 10;
+		right_limit = 490;
+		dest_rect = dlog_dest_rect;
+		dest = 2;
+		mode = 0;
+		dest_rect.top += pc * 24 + 18;
+		dest_rect.bottom += pc * 24 + 18;
+		dest_bmp = (HBITMAP)dest_dc;
+	}
+	else {
+		name_width = string_length(adven[pc].name, main_dc);
+		right_limit = pc_buttons[0][1].left - 5;
+		//dest_rect.left = pc_buttons[i][1].left - 16;
+		dest_rect.left = name_width + 33;
+		dest_rect.right = dest_rect.left + 12;
+		dest_rect.top += pc * 13;
+		dest_rect.bottom += pc * 13;
+		dest_bmp = pc_stats_gworld;
+	}
+	draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
+}
 
 void print_party_stats() {
 	add_string_to_buf("PARTY STATS:");

--- a/src/Windows Code Release 3/text.cpp
+++ b/src/Windows Code Release 3/text.cpp
@@ -118,6 +118,7 @@ static void place_buy_button(short position,short pc_num,short item_num,HDC hdc)
 static void place_item_bottom_buttons();
 static void place_item_button(short which_button_to_put,short which_slot,short which_button_position,short extra_val);
 static short print_terrain(location space);
+static void draw_pc_effects_bmp(short pc, HBITMAP dest_bmp);
 
 
 static void DrawString(const char* string, short x, short y, HDC hdc)
@@ -250,7 +251,7 @@ void put_pc_screen()
 					  to_draw,0,10);
 					SetTextColor(hdc,PALETTEINDEX(c[0]));
 					SelectObject(hdc,store_bmp);
-					draw_pc_effects(i,NULL);
+					draw_pc_effects_bmp(i, pc_stats_gworld);
 					SelectObject(hdc,pc_stats_gworld);
 					break;
 				case 2:
@@ -897,7 +898,7 @@ static void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventure
 		}	
 }
 
-static void draw_pc_effects_dc(short pc, HDC dest_dc)
+void draw_pc_effects_dc(short pc, HDC dest_dc)
 {
 	RECT dest_rect = BOE_INIT_RECT(66, 354, 78, 366);
 	dest_rect.top += pc * 24 + 18;
@@ -914,19 +915,6 @@ static void draw_pc_effects_bmp(short pc, HBITMAP dest_bmp)
 	dest_rect.top += pc * 13;
 	dest_rect.bottom += pc * 13;
 	draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, pc_buttons[0][1].left - 5, 1, 0);
-}
-
-void draw_pc_effects(short pc, HDC dest_dc)
-//short pc; // 10 + x -> draw for pc x, but on spell dialog  
-{
-	if (pc >= 10)
-	{
-		draw_pc_effects_dc(pc - 10, dest_dc);
-	}
-	else
-	{
-		draw_pc_effects_bmp(pc, pc_stats_gworld);
-	}
 }
 
 void print_party_stats() {

--- a/src/Windows Code Release 3/text.cpp
+++ b/src/Windows Code Release 3/text.cpp
@@ -896,45 +896,52 @@ static void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventure
 		}	
 }
 
+static void draw_pc_effects_dc(short pc, HDC dest_dc)
+{
+	RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27), dlog_dest_rect = BOE_INIT_RECT(66, 354, 78, 366);
+	short right_limit = 250;
+	short dest = 0; // 0 - in gworld  2 - on dialog
+	short mode = 1;
+	HBITMAP dest_bmp;
+
+	right_limit = 490;
+	dest_rect = dlog_dest_rect;
+	dest = 2;
+	mode = 0;
+	dest_rect.top += pc * 24 + 18;
+	dest_rect.bottom += pc * 24 + 18;
+	dest_bmp = (HBITMAP)dest_dc;
+	draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
+}
+
+static void draw_pc_effects_bmp(short pc, HBITMAP dest_bmp)
+{
+	RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27);
+	short right_limit = 250;
+	short dest = 0; // 0 - in gworld  2 - on dialog
+	short name_width, mode = 1;
+
+	name_width = string_length(adven[pc].name, main_dc);
+	right_limit = pc_buttons[0][1].left - 5;
+	//dest_rect.left = pc_buttons[i][1].left - 16;
+	dest_rect.left = name_width + 33;
+	dest_rect.right = dest_rect.left + 12;
+	dest_rect.top += pc * 13;
+	dest_rect.bottom += pc * 13;
+	dest_bmp = pc_stats_gworld;
+	draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
+}
+
 void draw_pc_effects(short pc, HDC dest_dc)
 //short pc; // 10 + x -> draw for pc x, but on spell dialog  
 {
 	if (pc >= 10)
 	{
-		pc -= 10;
-
-		RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27), dlog_dest_rect = BOE_INIT_RECT(66, 354, 78, 366);
-		short right_limit = 250;
-		short dest = 0; // 0 - in gworld  2 - on dialog
-		short mode = 1;
-		HBITMAP dest_bmp;
-
-		right_limit = 490;
-		dest_rect = dlog_dest_rect;
-		dest = 2;
-		mode = 0;
-		dest_rect.top += pc * 24 + 18;
-		dest_rect.bottom += pc * 24 + 18;
-		dest_bmp = (HBITMAP)dest_dc;
-		draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
+		draw_pc_effects_dc(pc - 10, dest_dc);
 	}
 	else
 	{
-		RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27);
-		short right_limit = 250;
-		short dest = 0; // 0 - in gworld  2 - on dialog
-		short name_width, mode = 1;
-		HBITMAP dest_bmp;
-
-		name_width = string_length(adven[pc].name, main_dc);
-		right_limit = pc_buttons[0][1].left - 5;
-		//dest_rect.left = pc_buttons[i][1].left - 16;
-		dest_rect.left = name_width + 33;
-		dest_rect.right = dest_rect.left + 12;
-		dest_rect.top += pc * 13;
-		dest_rect.bottom += pc * 13;
-		dest_bmp = pc_stats_gworld;
-		draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
+		draw_pc_effects_bmp(pc, pc_stats_gworld);
 	}
 }
 

--- a/src/Windows Code Release 3/text.cpp
+++ b/src/Windows Code Release 3/text.cpp
@@ -809,7 +809,7 @@ const RECT c_source_rects[18] = {
 };
 
 // dest: 0 - in gworld  2 - on dialog
-static void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventurer, const RECT& dest_rect_start, short right_limit, short mode, short dest)
+static void draw_pc_effects_ex(RectDrawDestination dest_bmp, const pc_record_type& adventurer, const RECT& dest_rect_start, short right_limit, short mode, short dest)
 {
 	RECT dest_rect{ dest_rect_start };
 
@@ -817,82 +817,82 @@ static void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventure
 		return;
 			
 	if ((adventurer.status[0] > 0) && (dest_rect.right < right_limit)) {
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[4],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[4],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adventurer.status[1] > 0) {
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[2],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[2],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adventurer.status[1] < 0) {
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[3],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[3],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adventurer.status[2] > 0) {
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[(adventurer.status[2] > 4) ? 1 : 0],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[(adventurer.status[2] > 4) ? 1 : 0],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adventurer.status[4] > 0) {
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[5],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[5],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adventurer.status[3] > 0) {
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[6],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[6],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adventurer.status[3] < 0) {
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[8],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[8],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adventurer.status[5] > 0) && (dest_rect.right < right_limit)) {
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[9],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[9],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adventurer.status[6] > 0) && (dest_rect.right < right_limit)) {
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[10],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[10],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adventurer.status[7] > 0) && (dest_rect.right < right_limit)){
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[11],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[11],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adventurer.status[8] > 0) && (dest_rect.right < right_limit)){
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[12],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[12],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adventurer.status[9] > 0) && (dest_rect.right < right_limit)){
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[13],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[13],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adventurer.status[10] > 0) && (dest_rect.right < right_limit)){
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[14],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[14],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adventurer.status[11] > 0) && (dest_rect.right < right_limit)){
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[15],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[15],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adventurer.status[12] > 0) && (dest_rect.right < right_limit)){
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[16],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[16],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adventurer.status[13] > 0) && (dest_rect.right < right_limit)){
-		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[17],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item(mixed_gworld,c_source_rects[17],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
@@ -903,7 +903,7 @@ void draw_pc_effects_dc(short pc, HDC dest_dc)
 	RECT dest_rect = BOE_INIT_RECT(66, 354, 78, 366);
 	dest_rect.top += pc * 24 + 18;
 	dest_rect.bottom += pc * 24 + 18;
-	draw_pc_effects_ex(reinterpret_cast<HBITMAP>(dest_dc), adven[pc], dest_rect, 490, 0, 2);
+	draw_pc_effects_ex(dest_dc, adven[pc], dest_rect, 490, 0, 2);
 }
 
 static void draw_pc_effects_bmp(short pc, HBITMAP dest_bmp)

--- a/src/Windows Code Release 3/text.cpp
+++ b/src/Windows Code Release 3/text.cpp
@@ -798,18 +798,18 @@ short get_tnl(pc_record_type *pc)
 }
 
 
+const RECT c_source_rects[18] = {
+	BOE_INIT_RECT(55,0,67,12), BOE_INIT_RECT(55,12,67,24), BOE_INIT_RECT(55,24,67,36),
+	BOE_INIT_RECT(67,0,79,12), BOE_INIT_RECT(67,12,79,24), BOE_INIT_RECT(67,24,79,36),
+	BOE_INIT_RECT(79,0,91,12), BOE_INIT_RECT(79,12,91,24), BOE_INIT_RECT(79,24,91,36),
+	BOE_INIT_RECT(91,0,103,12), BOE_INIT_RECT(91,12,103,24), BOE_INIT_RECT(91,24,103,36),
+	BOE_INIT_RECT(103,0,115,12), BOE_INIT_RECT(103,12,115,24), BOE_INIT_RECT(103,24,115,36),
+	BOE_INIT_RECT(115,0,127,12), BOE_INIT_RECT(115,12,127,24), BOE_INIT_RECT(115,24,127,36)
+};
 
 void draw_pc_effects(short pc,HDC dest_dc)
 //short pc; // 10 + x -> draw for pc x, but on spell dialog  
 {
-	const RECT source_rects[18] = {
-		BOE_INIT_RECT(55,0,67,12), BOE_INIT_RECT(55,12,67,24), BOE_INIT_RECT(55,24,67,36),
-		BOE_INIT_RECT(67,0,79,12), BOE_INIT_RECT(67,12,79,24), BOE_INIT_RECT(67,24,79,36),
-		BOE_INIT_RECT(79,0,91,12), BOE_INIT_RECT(79,12,91,24), BOE_INIT_RECT(79,24,91,36),
-		BOE_INIT_RECT(91,0,103,12), BOE_INIT_RECT(91,12,103,24), BOE_INIT_RECT(91,24,103,36),
-		BOE_INIT_RECT(103,0,115,12), BOE_INIT_RECT(103,12,115,24), BOE_INIT_RECT(103,24,115,36),
-		BOE_INIT_RECT(115,0,127,12), BOE_INIT_RECT(115,12,127,24), BOE_INIT_RECT(115,24,127,36)
-	};
 	RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27), dlog_dest_rect = BOE_INIT_RECT(66, 354, 78, 366);
 	short right_limit = 250;
 	short dest = 0; // 0 - in gworld  2 - on dialog
@@ -841,82 +841,82 @@ void draw_pc_effects(short pc,HDC dest_dc)
 		return;
 			
 	if ((adven[pc].status[0] > 0) && (dest_rect.right < right_limit)) { 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[4],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[4],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[1] > 0) { 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[2],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[2],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[1] < 0) { 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[3],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[3],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[2] > 0) { 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[(adven[pc].status[2] > 4) ? 1 : 0],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[(adven[pc].status[2] > 4) ? 1 : 0],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[4] > 0) { 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[5],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[5],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[3] > 0) { 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[6],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[6],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if (adven[pc].status[3] < 0) { 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[8],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[8],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adven[pc].status[5] > 0) && (dest_rect.right < right_limit)) { 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[9],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[9],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adven[pc].status[6] > 0) && (dest_rect.right < right_limit)) { 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[10],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[10],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adven[pc].status[7] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[11],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[11],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adven[pc].status[8] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[12],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[12],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}
 	if ((adven[pc].status[9] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[13],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[13],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adven[pc].status[10] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[14],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[14],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adven[pc].status[11] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[15],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[15],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adven[pc].status[12] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[16],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[16],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	
 	if ((adven[pc].status[13] > 0) && (dest_rect.right < right_limit)){ 
-		rect_draw_some_item_bmp(mixed_gworld,source_rects[17],dest_bmp,dest_rect,mode,dest);
+		rect_draw_some_item_bmp(mixed_gworld,c_source_rects[17],dest_bmp,dest_rect,mode,dest);
 		dest_rect.left += 13;
 		dest_rect.right += 13;
 		}	

--- a/src/Windows Code Release 3/text.cpp
+++ b/src/Windows Code Release 3/text.cpp
@@ -899,14 +899,16 @@ static void draw_pc_effects_ex(HBITMAP dest_bmp, const pc_record_type& adventure
 void draw_pc_effects(short pc, HDC dest_dc)
 //short pc; // 10 + x -> draw for pc x, but on spell dialog  
 {
-	RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27), dlog_dest_rect = BOE_INIT_RECT(66, 354, 78, 366);
-	short right_limit = 250;
-	short dest = 0; // 0 - in gworld  2 - on dialog
-	short name_width, mode = 1;
-	HBITMAP dest_bmp;
-
-	if (pc >= 10) {
+	if (pc >= 10)
+	{
 		pc -= 10;
+
+		RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27), dlog_dest_rect = BOE_INIT_RECT(66, 354, 78, 366);
+		short right_limit = 250;
+		short dest = 0; // 0 - in gworld  2 - on dialog
+		short mode = 1;
+		HBITMAP dest_bmp;
+
 		right_limit = 490;
 		dest_rect = dlog_dest_rect;
 		dest = 2;
@@ -914,8 +916,16 @@ void draw_pc_effects(short pc, HDC dest_dc)
 		dest_rect.top += pc * 24 + 18;
 		dest_rect.bottom += pc * 24 + 18;
 		dest_bmp = (HBITMAP)dest_dc;
+		draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
 	}
-	else {
+	else
+	{
+		RECT dest_rect = BOE_INIT_RECT(18, 15, 30, 27);
+		short right_limit = 250;
+		short dest = 0; // 0 - in gworld  2 - on dialog
+		short name_width, mode = 1;
+		HBITMAP dest_bmp;
+
 		name_width = string_length(adven[pc].name, main_dc);
 		right_limit = pc_buttons[0][1].left - 5;
 		//dest_rect.left = pc_buttons[i][1].left - 16;
@@ -924,8 +934,8 @@ void draw_pc_effects(short pc, HDC dest_dc)
 		dest_rect.top += pc * 13;
 		dest_rect.bottom += pc * 13;
 		dest_bmp = pc_stats_gworld;
+		draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
 	}
-	draw_pc_effects_ex(dest_bmp, adven[pc], dest_rect, right_limit, mode, dest);
 }
 
 void print_party_stats() {

--- a/src/Windows Code Release 3/text.cpp
+++ b/src/Windows Code Release 3/text.cpp
@@ -807,6 +807,8 @@ const RECT c_source_rects[18] = {
 	BOE_INIT_RECT(115,0,127,12), BOE_INIT_RECT(115,12,127,24), BOE_INIT_RECT(115,24,127,36)
 };
 
+void draw_pc_effects_ex(HBITMAP dest_bmp, short pc, RECT dest_rect, short right_limit, short mode, short dest);
+
 void draw_pc_effects(short pc,HDC dest_dc)
 //short pc; // 10 + x -> draw for pc x, but on spell dialog  
 {
@@ -836,7 +838,11 @@ void draw_pc_effects(short pc,HDC dest_dc)
 			dest_rect.bottom += pc * 13;
 			dest_bmp = pc_stats_gworld;
 			}
-			
+	draw_pc_effects_ex(dest_bmp, pc, dest_rect, right_limit, mode, dest);
+}
+
+void draw_pc_effects_ex(HBITMAP dest_bmp, short pc, RECT dest_rect, short right_limit, short mode, short dest)
+{
 	if (adven[pc].main_status % 10 != 1)
 		return;
 			

--- a/src/Windows Code Release 3/text.h
+++ b/src/Windows Code Release 3/text.h
@@ -8,7 +8,7 @@ short first_active_pc();
 void refresh_stat_areas(short mode);
 short total_encumberance(short pc_num);
 short get_tnl(pc_record_type *pc);
-void draw_pc_effects(short pc,HDC dest_dc);
+void draw_pc_effects_dc(short pc,HDC dest_dc);
 void print_party_stats() ;
 short do_look(location space);
 short town_boat_there(location where);


### PR DESCRIPTION
Removed all reinterpret casts associated with HWND, HDC and HBITMAP common parameters and changed them to leverage std::variant initially in a relatively simplistic way.