### PR TITLE
Stop calling GetDC

### DIFF
--- a/src/Windows Code Release 3/PC editor/graphutl.cpp
+++ b/src/Windows Code Release 3/PC editor/graphutl.cpp
@@ -477,7 +477,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, RectDrawDestination dest,REC
 		dlog_draw = TRUE;
 		hdcMem = CreateCompatibleDC(destDC);
 		SelectObject(hdcMem, src);
-		SetMapMode(hdcMem,GetMapMode(GetDC(mainPtr)));
+		SetMapMode(hdcMem,GetMapMode(destDC));
 		SelectPalette(hdcMem,hpal,0);
 		}
 		else {
@@ -531,7 +531,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, RectDrawDestination dest,REC
 		if (main_win == 0) {
 			hdcMem3 = CreateCompatibleDC(hdcMem);
 			SelectObject(hdcMem3, std::get<HBITMAP>(dest));
-			SetMapMode(hdcMem3,GetMapMode(GetDC(mainPtr)));
+			SetMapMode(hdcMem3,GetMapMode(hdcMem));
 			SelectPalette(hdcMem3,hpal,0);
 			transbmp = CreateBitmap(src_rect.right - src_rect.left,
 						src_rect.bottom - src_rect.top,1,1,NULL);

--- a/src/Windows Code Release 3/Scen Ed/graphutl.cpp
+++ b/src/Windows Code Release 3/Scen Ed/graphutl.cpp
@@ -495,7 +495,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, RectDrawDestination dest,REC
 		dlog_draw = TRUE;
 		hdcMem = CreateCompatibleDC(destDC);
 		SelectObject(hdcMem, src);
-		SetMapMode(hdcMem,GetMapMode(GetDC(mainPtr)));
+		SetMapMode(hdcMem,GetMapMode(destDC));
 		SelectPalette(hdcMem,hpal,0);
 		SetStretchBltMode(hdcMem,STRETCH_DELETESCANS);
 		}
@@ -558,7 +558,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, RectDrawDestination dest,REC
 		if (main_win == 0) {
 			hdcMem3 = CreateCompatibleDC(hdcMem);
 			SelectObject(hdcMem3, std::get<HBITMAP>(dest));
-			SetMapMode(hdcMem3,GetMapMode(GetDC(mainPtr)));
+			SetMapMode(hdcMem3,GetMapMode(hdcMem));
 			SelectPalette(hdcMem3,hpal,0);
 			transbmp = CreateBitmap(src_rect.right - src_rect.left,
 						src_rect.bottom - src_rect.top,1,1,NULL);

--- a/src/Windows Code Release 3/graphutl.cpp
+++ b/src/Windows Code Release 3/graphutl.cpp
@@ -476,7 +476,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, RectDrawDestination dest,REC
 		dlog_draw = TRUE;
 		hdcMem = CreateCompatibleDC(destDC);
 		SelectObject(hdcMem, src);
-		SetMapMode(hdcMem,GetMapMode(GetDC(mainPtr)));
+		SetMapMode(hdcMem,GetMapMode(destDC));
 		SelectPalette(hdcMem,hpal,0);
 		}
 		else {
@@ -530,7 +530,7 @@ void rect_draw_some_item(HBITMAP src,RECT src_rect, RectDrawDestination dest,REC
 		if (main_win == 0) {
 			hdcMem3 = CreateCompatibleDC(hdcMem);
 			SelectObject(hdcMem3, std::get<HBITMAP>(dest));
-			SetMapMode(hdcMem3,GetMapMode(GetDC(mainPtr)));
+			SetMapMode(hdcMem3,GetMapMode(hdcMem));
 			SelectPalette(hdcMem3,hpal,0);
 			if ((src_rect.right - src_rect.left < 72) &&
 				(src_rect.bottom - src_rect.top < 72))


### PR DESCRIPTION
This was a mistake: one should never call GetDC without also calling ReleaseDC. We still may not have correctly addressed https://github.com/CorrodedCoder/Blades-of-Exile/issues/14 but it's better than it was. In reading about [Get|Set]MapMode my guess is that this app only uses MM_TEXT, so this probably doesn't really matter.